### PR TITLE
Allow QKSMS notifications to be handled as a generic notification if …

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -132,7 +132,6 @@ public class NotificationListener extends NotificationListenerService {
                 source.equals("com.android.systemui") ||
                 source.equals("com.android.dialer") ||
                 source.equals("com.android.mms") ||
-                source.equals("com.moez.QKSMS") ||
                 source.equals("com.cyanogenmod.eleven")) {
             return;
         }
@@ -145,6 +144,12 @@ public class NotificationListener extends NotificationListenerService {
 
         if (source.equals("com.fsck.k9")) {
             if (!"never".equals(sharedPrefs.getString("notification_mode_k9mail", "when_screen_off"))) {
+                return;
+            }
+        }
+
+        if (source.equals("com.moez.QKSMS")) {
+            if (!"never".equals(sharedPrefs.getString("notification_mode_sms", "when_screen_off"))) {
                 return;
             }
         }
@@ -166,6 +171,9 @@ public class NotificationListener extends NotificationListenerService {
             case "com.fsck.k9":
             case "com.android.email":
                 notificationKind = NotificationKind.EMAIL;
+                break;
+            case "com.moez.QKSMS":
+                notificationKind = NotificationKind.SMS;
                 break;
             case "eu.siacs.conversations":
                 notificationKind = NotificationKind.CHAT;

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/NotificationKind.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/NotificationKind.java
@@ -7,5 +7,6 @@ public enum NotificationKind {
     CHAT,
     EMAIL,
     FACEBOOK,
+    SMS,
     TWITTER,
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
@@ -635,6 +635,10 @@ public class PebbleProtocol extends GBDeviceProtocol {
                         icon_id = PebbleIconID.GENERIC_EMAIL;
                         color_id = PebbleColor.JaegerGreen;
                         break;
+                    case SMS:
+                        icon_id = PebbleIconID.GENERIC_SMS;
+                        color_id = PebbleColor.VividViolet;
+                        break;
                     case FACEBOOK:
                         icon_id = PebbleIconID.NOTIFICATION_FACEBOOK;
                         color_id = PebbleColor.VeryLightBlue;


### PR DESCRIPTION
…SMS notification mode is set to "never"

This makes it possible to use the "Open on Phone" and individial dismiss feature with QKSMS.