### PR TITLE
Initial support for newer MI devices.

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
@@ -183,6 +183,8 @@ public class DeviceCommunicationService extends Service {
                             } else {
                                 deviceSupport.connect();
                             }
+                        } else {
+                            GB.toast(this, getString(R.string.cannot_connect, "Can't create device support"), Toast.LENGTH_SHORT, GB.ERROR);
                         }
                     } catch (Exception e) {
                         GB.toast(this, getString(R.string.cannot_connect, e.getMessage()), Toast.LENGTH_SHORT, GB.ERROR);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceSupportFactory.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceSupportFactory.java
@@ -79,7 +79,7 @@ public class DeviceSupportFactory {
 
             try {
                 BluetoothDevice btDevice = mBtAdapter.getRemoteDevice(deviceAddress);
-                if (btDevice.getName() == null || btDevice.getName().equals("MI")) { //FIXME: workaround for Miband not being paired
+                if (btDevice.getName() == null || btDevice.getName().startsWith("MI")) { //FIXME: workaround for Miband not being paired
                     gbDevice = new GBDevice(deviceAddress, "MI", DeviceType.MIBAND);
                     deviceSupport = new ServiceDeviceSupport(new MiBandSupport(), EnumSet.of(ServiceDeviceSupport.Flags.THROTTLING, ServiceDeviceSupport.Flags.BUSY_CHECKING));
                 } else if (btDevice.getName().indexOf("Pebble") == 0) {


### PR DESCRIPTION
Hi, as an owner of MI1A (in yesterdays comment I mistyped it as MI1S), I am willing to add support for it. So, here is my first baby step - try to pair :)

I also added notification toast when no device support is found. But it will be better to close PairingActivity and show error message.

 After changes device still not pair but now there is an communication error. I have found that MI1A UserInfo differs from MI.