### PR TITLE
Fix #221 - Cast pair.first as integer

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LimitedQueue.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LimitedQueue.java
@@ -23,7 +23,7 @@ public class LimitedQueue {
     public void remove(int id) {
         for (Iterator<Pair> iter = list.iterator(); iter.hasNext(); ) {
             Pair pair = iter.next();
-            if (pair.first == id) {
+            if ((Integer) pair.first == id) {
                 iter.remove();
             }
         }


### PR DESCRIPTION
This commit fixes the following compilation error:

```
:app:compileDebugJavaWithJavac
/home/bob/dev/Gadgetbridge/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LimitedQueue.java:26:
error: incomparable types: Object and int
            if (pair.first == id) {
                           ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
:app:compileDebugJavaWithJavac FAILED

FAILURE: Build failed with an exception.
```