### PR TITLE
Heartrate sleep support Mi1S

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/AbstractSettingsActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/AbstractSettingsActivity.java
@@ -33,7 +33,7 @@ public abstract class AbstractSettingsActivity extends PreferenceActivity {
         }
 
         public void updateSummary(Preference preference, Object value) {
-            String stringValue = value.toString();
+            String stringValue = String.valueOf(value);
 
             if (preference instanceof ListPreference) {
                 // For list preferences, look up the correct display value in

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandConst.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandConst.java
@@ -15,6 +15,8 @@ public final class MiBandConst {
     public static final String PREF_MIBAND_FITNESS_GOAL = "mi_fitness_goal";
     public static final String PREF_MIBAND_DONT_ACK_TRANSFER = "mi_dont_ack_transfer";
     public static final String PREF_MIBAND_RESERVE_ALARM_FOR_CALENDAR = "mi_reserve_alarm_calendar";
+    public static final String PREF_MIBAND_USE_HR_FOR_SLEEP_DETECTION = "mi_hr_sleep_detection";
+
 
 
     public static final String ORIGIN_SMS = "sms";

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandCoordinator.java
@@ -135,6 +135,11 @@ public class MiBandCoordinator extends AbstractDeviceCoordinator {
         return location;
     }
 
+    public static boolean getHeartrateSleepSupport(String miBandAddress) throws IllegalArgumentException {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(GBApplication.getContext());
+        return prefs.getBoolean(MiBandConst.PREF_MIBAND_USE_HR_FOR_SLEEP_DETECTION, false);
+    }
+
     public static int getFitnessGoal(String miBandAddress) throws IllegalArgumentException {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(GBApplication.getContext());
         return Integer.parseInt(prefs.getString(MiBandConst.PREF_MIBAND_FITNESS_GOAL, "10000"));

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandPreferencesActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandPreferencesActivity.java
@@ -18,6 +18,7 @@ import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PR
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_DONT_ACK_TRANSFER;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_FITNESS_GOAL;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_RESERVE_ALARM_FOR_CALENDAR;
+import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_USE_HR_FOR_SLEEP_DETECTION;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_WEARSIDE;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_USER_ALIAS;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.VIBRATION_COUNT;
@@ -54,6 +55,7 @@ public class MiBandPreferencesActivity extends AbstractSettingsActivity {
                 PREF_MIBAND_FITNESS_GOAL,
                 PREF_MIBAND_DONT_ACK_TRANSFER,
                 PREF_MIBAND_RESERVE_ALARM_FOR_CALENDAR,
+                PREF_MIBAND_USE_HR_FOR_SLEEP_DETECTION,
                 getNotificationPrefKey(VIBRATION_PROFILE, ORIGIN_SMS),
                 getNotificationPrefKey(VIBRATION_COUNT, ORIGIN_SMS),
                 getNotificationPrefKey(VIBRATION_PROFILE, ORIGIN_INCOMING_CALL),

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband/MiBandSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband/MiBandSupport.java
@@ -109,6 +109,7 @@ public class MiBandSupport extends AbstractBTLEDeviceSupport {
                 .sendUserInfo(builder)
                 .checkAuthenticationNeeded(builder, getDevice())
                 .setWearLocation(builder)
+                .setHeartrateSleepSupport(builder)
                 .setFitnessGoal(builder)
                 .enableFurtherNotifications(builder, true)
                 .setCurrentTime(builder)
@@ -362,6 +363,30 @@ public class MiBandSupport extends AbstractBTLEDeviceSupport {
                     MiBandService.COMMAND_SET_WEAR_LOCATION,
                     (byte) location
             });
+        } else {
+            LOG.info("Unable to set Wear Location");
+        }
+        return this;
+    }
+
+    /**
+     * Part of device initialization process. Do not call manually.
+     *
+     * @param transaction
+     * @return
+     */
+    private MiBandSupport setHeartrateSleepSupport(TransactionBuilder transaction) {
+        LOG.info("Attempting to set heartrate sleep support...");
+        BluetoothGattCharacteristic characteristic = getCharacteristic(MiBandService.UUID_CHARACTERISTIC_HEART_RATE_CONTROL_POINT);
+        if (characteristic != null) {
+            if(MiBandCoordinator.getHeartrateSleepSupport(getDevice().getAddress())) {
+                LOG.info("Enabling heartrate sleep support...");
+                transaction.write(getCharacteristic(MiBandService.UUID_CHARACTERISTIC_HEART_RATE_CONTROL_POINT), startHeartMeasurementSleep);
+            }
+            else {
+                LOG.info("Disabling heartrate sleep support...");
+                transaction.write(getCharacteristic(MiBandService.UUID_CHARACTERISTIC_HEART_RATE_CONTROL_POINT), stopHeartMeasurementSleep);
+            }
         } else {
             LOG.info("Unable to set Wear Location");
         }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband/MiBandSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband/MiBandSupport.java
@@ -376,20 +376,24 @@ public class MiBandSupport extends AbstractBTLEDeviceSupport {
      * @return
      */
     private MiBandSupport setHeartrateSleepSupport(TransactionBuilder transaction) {
-        LOG.info("Attempting to set heartrate sleep support...");
-        BluetoothGattCharacteristic characteristic = getCharacteristic(MiBandService.UUID_CHARACTERISTIC_HEART_RATE_CONTROL_POINT);
-        if (characteristic != null) {
-            if(MiBandCoordinator.getHeartrateSleepSupport(getDevice().getAddress())) {
-                LOG.info("Enabling heartrate sleep support...");
-                transaction.write(getCharacteristic(MiBandService.UUID_CHARACTERISTIC_HEART_RATE_CONTROL_POINT), startHeartMeasurementSleep);
+        if (supportsHeartRate()) {
+            LOG.info("Attempting to set heartrate sleep support...");
+            BluetoothGattCharacteristic characteristic = getCharacteristic(MiBandService.UUID_CHARACTERISTIC_HEART_RATE_CONTROL_POINT);
+            if (characteristic != null) {
+                if(MiBandCoordinator.getHeartrateSleepSupport(getDevice().getAddress())) {
+                    LOG.info("Enabling heartrate sleep support...");
+                    transaction.write(getCharacteristic(MiBandService.UUID_CHARACTERISTIC_HEART_RATE_CONTROL_POINT), startHeartMeasurementSleep);
+                }
+                else {
+                    LOG.info("Disabling heartrate sleep support...");
+                    transaction.write(getCharacteristic(MiBandService.UUID_CHARACTERISTIC_HEART_RATE_CONTROL_POINT), stopHeartMeasurementSleep);
+                }
+            } else {
+                LOG.info("Unable to set Heartrate sleep support");
             }
-            else {
-                LOG.info("Disabling heartrate sleep support...");
-                transaction.write(getCharacteristic(MiBandService.UUID_CHARACTERISTIC_HEART_RATE_CONTROL_POINT), stopHeartMeasurementSleep);
-            }
-        } else {
-            LOG.info("Unable to set Wear Location");
-        }
+
+        } else
+            GB.toast(getContext(), "Heart rate is not supported on this device", Toast.LENGTH_LONG, GB.ERROR);
         return this;
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,6 +213,8 @@
     <string name="miband_fwinstaller_incompatible_version">Incompatible firmware</string>
     <string name="fwinstaller_firmware_not_compatible_to_device">This firmware is not compatible with the device</string>
     <string name="miband_prefs_reserve_alarm_calendar">Alarms to reserve for upcoming events</string>
+    <string name="miband_prefs_hr_sleep_detection">Use Heartrate Sensor to improve sleep detection</string>
+
     <string name="waiting_for_reconnect">waiting for reconnect</string>
     <string name="appmananger_app_reinstall">Reinstall</string>
 

--- a/app/src/main/res/xml/miband_preferences.xml
+++ b/app/src/main/res/xml/miband_preferences.xml
@@ -30,6 +30,10 @@
             android:maxLength="1"
             android:digits="0123"
             android:title="@string/miband_prefs_reserve_alarm_calendar" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="mi_hr_sleep_detection"
+            android:title="@string/miband_prefs_hr_sleep_detection" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Add a setting to preferences to enable support HearRate for Sleep detection.

Had some problems with the Preferences Framework due to using a Boolean Checkbox.

Settings are not synced on leaving the settings screen, only on reconnecting the device?

References https://github.com/Freeyourgadget/Gadgetbridge/issues/232