### PR TITLE
Entity generation fix, gradle and travis build script fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: android
+
 jdk:
   - oraclejdk8
   - oraclejdk7
+env:
+  - GRADLE_OPTS="-Xmx2048m -XX:MaxPermSize=512m"
+
 android:
   components:
     # Uncomment the lines below if you want to

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
   - oraclejdk7
 env:
-  - GRADLE_OPTS="-Xmx2048m -XX:MaxPermSize=512m"
+  - GRADLE_OPTS="-XX:MaxPermSize=256m"
 
 android:
   components:

--- a/GBDaoGenerator/build.gradle
+++ b/GBDaoGenerator/build.gradle
@@ -13,14 +13,16 @@ sourceSets {
     main {
         java {
             srcDir 'src'
-            srcDir 'src-gen'
         }
     }
 }
 
-task (genSources, type: JavaExec) {
-    main = "nodomain.freeyourgadget.gadgetbridge.daogen.GBDaoGenerator"
+mainClassName = "nodomain.freeyourgadget.gadgetbridge.daogen.GBDaoGenerator"
+
+task genSources(type: JavaExec) {
+    main = mainClassName
     classpath = sourceSets.main.runtimeClasspath
+    workingDir = '../'
 }
 
 artifacts {

--- a/GBDaoGenerator/src/nodomain/freeyourgadget/gadgetbridge/daogen/GBDaoGenerator.java
+++ b/GBDaoGenerator/src/nodomain/freeyourgadget/gadgetbridge/daogen/GBDaoGenerator.java
@@ -40,7 +40,7 @@ public class GBDaoGenerator {
 
         addActivitySample(schema, user, device);
 
-        new DaoGenerator().generateAll(schema, "../app/src/main/gen");
+        new DaoGenerator().generateAll(schema, "app/src/main/java");
     }
 
     private static Entity addUserInfo(Schema schema, Entity userAttributes) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
It's now able to generate the entities onto the `app` module, and the mainClassName script error has been solved.

I think that the entities package should be put in `.gitignore` but I will defer that decision to @cpfeiffer 
