### PR TITLE
Add support for shifting the device time by N hours

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandConst.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandConst.java
@@ -16,6 +16,7 @@ public final class MiBandConst {
     public static final String PREF_MIBAND_DONT_ACK_TRANSFER = "mi_dont_ack_transfer";
     public static final String PREF_MIBAND_RESERVE_ALARM_FOR_CALENDAR = "mi_reserve_alarm_calendar";
     public static final String PREF_MIBAND_USE_HR_FOR_SLEEP_DETECTION = "mi_hr_sleep_detection";
+	public static final String PREF_MIBAND_DEVICE_TIME_OFFSET_HOURS = "mi_device_time_offset_hours";
 
 
     public static final String ORIGIN_SMS = "sms";

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandCoordinator.java
@@ -140,6 +140,11 @@ public class MiBandCoordinator extends AbstractDeviceCoordinator {
         return location;
     }
 
+	public static int getDeviceTimeOffsetHours() throws IllegalArgumentException {
+		Prefs prefs = GBApplication.getPrefs();
+		return prefs.getInt(MiBandConst.PREF_MIBAND_DEVICE_TIME_OFFSET_HOURS, 0);
+	}
+
     public static boolean getHeartrateSleepSupport(String miBandAddress) throws IllegalArgumentException {
         Prefs prefs = GBApplication.getPrefs();
         return prefs.getBoolean(MiBandConst.PREF_MIBAND_USE_HR_FOR_SLEEP_DETECTION, false);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandDateConverter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandDateConverter.java
@@ -40,6 +40,10 @@ public class MiBandDateConverter {
                     value[offset + 4],
                     value[offset + 5]);
 
+	        int offsetInHours = MiBandCoordinator.getDeviceTimeOffsetHours();
+	        if(offsetInHours != 0)
+		        timestamp.add(Calendar.HOUR_OF_DAY,-offsetInHours);
+
             return timestamp;
         }
 
@@ -53,6 +57,18 @@ public class MiBandDateConverter {
      * @return
      */
     public static byte[] calendarToRawBytes(Calendar timestamp) {
+
+	    // The mi-band device currently records sleep
+	    // only if it happens after 10pm and before 7am.
+	    // The offset is used to trick the device to record sleep
+	    // in non-standard hours.
+	    // If you usually sleep, say, from 6am to 2pm, set the
+	    // shift to -8, so at 6am the device thinks it's still 10pm
+	    // of the day before.
+	    int offsetInHours = MiBandCoordinator.getDeviceTimeOffsetHours();
+	    if(offsetInHours != 0)
+			timestamp.add(Calendar.HOUR_OF_DAY,offsetInHours);
+
         return new byte[]{
                 (byte) (timestamp.get(Calendar.YEAR) - 2000),
                 (byte) timestamp.get(Calendar.MONTH),

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandPreferencesActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandPreferencesActivity.java
@@ -16,6 +16,7 @@ import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.OR
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.ORIGIN_PEBBLEMSG;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.ORIGIN_SMS;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_ADDRESS;
+import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_DEVICE_TIME_OFFSET_HOURS;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_DONT_ACK_TRANSFER;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_FITNESS_GOAL;
 import static nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst.PREF_MIBAND_RESERVE_ALARM_FOR_CALENDAR;
@@ -62,6 +63,7 @@ public class MiBandPreferencesActivity extends AbstractSettingsActivity {
                 PREF_MIBAND_ADDRESS,
                 PREF_MIBAND_FITNESS_GOAL,
                 PREF_MIBAND_RESERVE_ALARM_FOR_CALENDAR,
+		        PREF_MIBAND_DEVICE_TIME_OFFSET_HOURS,
                 getNotificationPrefKey(VIBRATION_COUNT, ORIGIN_SMS),
                 getNotificationPrefKey(VIBRATION_COUNT, ORIGIN_INCOMING_CALL),
                 getNotificationPrefKey(VIBRATION_COUNT, ORIGIN_K9MAIL),

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -238,4 +238,5 @@
   <string name="updatefirmwareoperation_firmware_not_sent">Firmware non inviato</string>
   <string name="charts_legend_heartrate">Battito cardiaco</string>
   <string name="live_activity_heart_rate">Battito cardiaco</string>
+	<string name="miband_prefs_device_time_offset_hours">Offset orologio del dispositivo in ore (per l\'identificazione del sonno dei lavoratori a turni)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,6 +237,7 @@
     <string name="fwinstaller_firmware_not_compatible_to_device">This firmware is not compatible with the device</string>
     <string name="miband_prefs_reserve_alarm_calendar">Alarms to reserve for upcoming events</string>
     <string name="miband_prefs_hr_sleep_detection">Use Heartrate Sensor to improve sleep detection</string>
+	<string name="miband_prefs_device_time_offset_hours">Device time offset in hours (for detecting sleep of shift workers)</string>
 
     <string name="waiting_for_reconnect">waiting for reconnect</string>
     <string name="appmananger_app_reinstall">Reinstall</string>

--- a/app/src/main/res/xml/miband_preferences.xml
+++ b/app/src/main/res/xml/miband_preferences.xml
@@ -35,6 +35,14 @@
             android:defaultValue="false"
             android:key="mi_hr_sleep_detection"
             android:title="@string/miband_prefs_hr_sleep_detection" />
+
+		<EditTextPreference
+			android:defaultValue="0"
+			android:inputType="numberSigned"
+			android:key="mi_device_time_offset_hours"
+			android:maxLength="2"
+			android:title="@string/miband_prefs_device_time_offset_hours" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Mi-band firmware seems to gather sleep data only if sleep is initiated in a certain period of the day, probably between 10pm and some hour in the middle of the night. This means that shift workers, or just anyone that has the habit to go to sleep at a very different time can't use mi-band for sleep tracking.

This commit attempts to work around this limitation. It adds an option that specifies a device time offset in hours. All the times sent to the device are shifted by this offset and all the times received from the device are shifted "back". In this way mi-band thinks to be in a different time zone and gathers sleep data at different hours but data view on the app side is unaffected.

Example of usage: if you usually go to sleep at 6am, set the offset to -8 hours. At 6 am the device will think it's still 10pm and will begin gathering sleep data.
