### PR TITLE
Set music info for PocketCasts

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DebugActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DebugActivity.java
@@ -218,7 +218,7 @@ public class DebugActivity extends GBActivity {
                 musicSpec.artist = editContent.getText().toString() + "(artist)";
                 musicSpec.album = editContent.getText().toString() + "(album)";
                 musicSpec.track = editContent.getText().toString() + "(track)";
-                musicSpec.duration = 10;
+                musicSpec.duration = 10 * 1000;
                 musicSpec.trackCount = 5;
                 musicSpec.trackNr = 2;
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DebugActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DebugActivity.java
@@ -37,6 +37,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.DeviceService;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationType;
 import nodomain.freeyourgadget.gadgetbridge.util.FileUtils;
@@ -222,6 +223,15 @@ public class DebugActivity extends GBActivity {
                 musicSpec.trackNr = 2;
 
                 GBApplication.deviceService().onSetMusicInfo(musicSpec);
+
+                MusicStateSpec stateSpec = new MusicStateSpec();
+                stateSpec.position = 0;
+                stateSpec.state = 0x01; // playing
+                stateSpec.playRate = 100;
+                stateSpec.repeat = 1;
+                stateSpec.shuffle = 1;
+
+                GBApplication.deviceService().onSetMusicState(stateSpec);
             }
         });
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DebugActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DebugActivity.java
@@ -218,7 +218,7 @@ public class DebugActivity extends GBActivity {
                 musicSpec.artist = editContent.getText().toString() + "(artist)";
                 musicSpec.album = editContent.getText().toString() + "(album)";
                 musicSpec.track = editContent.getText().toString() + "(track)";
-                musicSpec.duration = 10 * 1000;
+                musicSpec.duration = 10;
                 musicSpec.trackCount = 5;
                 musicSpec.trackNr = 2;
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/EventHandler.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/EventHandler.java
@@ -9,6 +9,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.Alarm;
 import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 
 /**
@@ -24,6 +25,8 @@ public interface EventHandler {
     void onSetAlarms(ArrayList<? extends Alarm> alarms);
 
     void onSetCallState(CallSpec callSpec);
+
+    void onSetMusicState(MusicStateSpec stateSpec);
 
     void onSetMusicInfo(MusicSpec musicSpec);
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -380,7 +380,7 @@ public class NotificationListener extends NotificationListenerService {
         if (d.containsKey(MediaMetadata.METADATA_KEY_TITLE))
             musicSpec.track = d.getString(MediaMetadata.METADATA_KEY_TITLE);
         if (d.containsKey(MediaMetadata.METADATA_KEY_DURATION))
-            musicSpec.duration = (int)d.getLong(MediaMetadata.METADATA_KEY_DURATION) / 1000;
+            musicSpec.duration = (int)d.getLong(MediaMetadata.METADATA_KEY_DURATION);
 
         // finally, tell the device about it
         GBApplication.deviceService().onSetMusicInfo(musicSpec);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -359,14 +359,16 @@ public class NotificationListener extends NotificationListenerService {
         stateSpec.shuffle = 1;
         switch (s.getState()) {
             case PlaybackState.STATE_PLAYING:
-                stateSpec.state = 0x01;
+                stateSpec.state = MusicStateSpec.STATE_PLAYING;
                 break;
             case PlaybackState.STATE_STOPPED:
+                stateSpec.state = MusicStateSpec.STATE_STOPPED;
+                break;
             case PlaybackState.STATE_PAUSED:
-                stateSpec.state = 0x00;
+                stateSpec.state = MusicStateSpec.STATE_PAUSED;
                 break;
             default:
-                stateSpec.state = 0x04;
+                stateSpec.state = MusicStateSpec.STATE_UNKNOWN;
                 break;
         }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -380,7 +380,7 @@ public class NotificationListener extends NotificationListenerService {
         if (d.containsKey(MediaMetadata.METADATA_KEY_TITLE))
             musicSpec.track = d.getString(MediaMetadata.METADATA_KEY_TITLE);
         if (d.containsKey(MediaMetadata.METADATA_KEY_DURATION))
-            musicSpec.duration = (int)d.getLong(MediaMetadata.METADATA_KEY_DURATION);
+            musicSpec.duration = (int)d.getLong(MediaMetadata.METADATA_KEY_DURATION) / 1000;
 
         // finally, tell the device about it
         GBApplication.deviceService().onSetMusicInfo(musicSpec);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -11,8 +11,14 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.media.MediaMetadata;
+import android.media.session.MediaController;
+import android.media.session.MediaSession;
+import android.media.session.PlaybackState;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
+import android.provider.MediaStore;
 import android.service.notification.NotificationListenerService;
 import android.service.notification.StatusBarNotification;
 import android.support.v4.app.NotificationCompat;
@@ -26,6 +32,7 @@ import java.util.List;
 
 import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationType;
 import nodomain.freeyourgadget.gadgetbridge.service.DeviceCommunicationService;
@@ -183,10 +190,8 @@ public class NotificationListener extends NotificationListenerService {
         String source = sbn.getPackageName();
         Notification notification = sbn.getNotification();
 
-        if (source.equals("au.com.shiftyjelly.pocketcasts")) {
-            if (handlePocketCastNotification(notification))
-                return;
-        }
+        if (handleMediaSessionNotification(notification))
+            return;
 
         if ((notification.flags & Notification.FLAG_ONGOING_EVENT) == Notification.FLAG_ONGOING_EVENT) {
             return;
@@ -318,32 +323,69 @@ public class NotificationListener extends NotificationListenerService {
     }
 
     /**
-     * Try to handle pocket cast notifications that tell info about the current play state.
+     * Try to handle media session notifications that tell info about the current play state.
+     *
      * @param notification The notification to handle.
      * @return true if notification was handled, false otherwise
      */
-    public boolean handlePocketCastNotification(Notification notification) {
+    public boolean handleMediaSessionNotification(Notification notification) {
+
+        // this code requires Android 5.0 or newer
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return false;
+        }
+
         MusicSpec musicSpec = new MusicSpec();
+        MusicStateSpec stateSpec = new MusicStateSpec();
 
         Bundle extras = notification.extras;
         if (extras == null)
             return false;
 
-        CharSequence title = extras.getCharSequence(Notification.EXTRA_TITLE);
-        if (title != null)
-            musicSpec.artist = title.toString();
-        if (extras.containsKey(Notification.EXTRA_TEXT)) {
-            CharSequence contentCS = extras.getCharSequence(Notification.EXTRA_TEXT);
-            if (contentCS != null)
-                musicSpec.track = contentCS.toString();
+        if (extras.get(Notification.EXTRA_MEDIA_SESSION) == null)
+            return false;
+
+        MediaController c;
+        try {
+            c = new MediaController(getApplicationContext(), (MediaSession.Token) extras.get(Notification.EXTRA_MEDIA_SESSION));
+        } catch (NullPointerException e) {
+            return false;
         }
 
-        musicSpec.album = "unknown";
+        PlaybackState s = c.getPlaybackState();
+        stateSpec.position = (int)s.getPosition();
+        stateSpec.playRate = Math.round(100 * s.getPlaybackSpeed());
+        stateSpec.repeat = 1;
+        stateSpec.shuffle = 1;
+        switch (s.getState()) {
+            case PlaybackState.STATE_PLAYING:
+                stateSpec.state = 0x01;
+                break;
+            case PlaybackState.STATE_STOPPED:
+            case PlaybackState.STATE_PAUSED:
+                stateSpec.state = 0x00;
+                break;
+            default:
+                stateSpec.state = 0x04;
+                break;
+        }
 
-        LOG.info("handlePocketCastsNotification: artist " + musicSpec.artist + ", track " + musicSpec.track);
+        MediaMetadata d = c.getMetadata();
+        if (d == null)
+            return false;
+        if (d.containsKey(MediaMetadata.METADATA_KEY_ARTIST))
+            musicSpec.artist = d.getString(MediaMetadata.METADATA_KEY_ARTIST);
+        if (d.containsKey(MediaMetadata.METADATA_KEY_ALBUM))
+            musicSpec.album = d.getString(MediaMetadata.METADATA_KEY_ALBUM);
+        if (d.containsKey(MediaMetadata.METADATA_KEY_TITLE))
+            musicSpec.track = d.getString(MediaMetadata.METADATA_KEY_TITLE);
+        if (d.containsKey(MediaMetadata.METADATA_KEY_DURATION))
+            musicSpec.duration = (int)d.getLong(MediaMetadata.METADATA_KEY_DURATION) / 1000;
 
         // finally, tell the device about it
         GBApplication.deviceService().onSetMusicInfo(musicSpec);
+        GBApplication.deviceService().onSetMusicState(stateSpec);
+
         return true;
     }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/impl/GBDeviceService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/impl/GBDeviceService.java
@@ -14,6 +14,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.DeviceService;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 import nodomain.freeyourgadget.gadgetbridge.service.DeviceCommunicationService;
 
@@ -122,6 +123,17 @@ public class GBDeviceService implements DeviceService {
         Intent intent = createIntent().setAction(ACTION_CALLSTATE)
                 .putExtra(EXTRA_CALL_PHONENUMBER, callSpec.number)
                 .putExtra(EXTRA_CALL_COMMAND, callSpec.command);
+        invokeService(intent);
+    }
+
+    @Override
+    public void onSetMusicState(MusicStateSpec stateSpec) {
+        Intent intent = createIntent().setAction(ACTION_SETMUSICSTATE)
+                .putExtra(EXTRA_MUSIC_REPEAT, stateSpec.repeat)
+                .putExtra(EXTRA_MUSIC_RATE, stateSpec.playRate)
+                .putExtra(EXTRA_MUSIC_STATE, stateSpec.state)
+                .putExtra(EXTRA_MUSIC_SHUFFLE, stateSpec.shuffle)
+                .putExtra(EXTRA_MUSIC_POSITION, stateSpec.position);
         invokeService(intent);
     }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/DeviceService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/DeviceService.java
@@ -18,6 +18,7 @@ public interface DeviceService extends EventHandler {
     String ACTION_CALLSTATE = PREFIX + ".action.callstate";
     String ACTION_SETTIME = PREFIX + ".action.settime";
     String ACTION_SETMUSICINFO = PREFIX + ".action.setmusicinfo";
+    String ACTION_SETMUSICSTATE = PREFIX + ".action.setmusicstate";
     String ACTION_REQUEST_DEVICEINFO = PREFIX + ".action.request_deviceinfo";
     String ACTION_REQUEST_APPINFO = PREFIX + ".action.request_appinfo";
     String ACTION_REQUEST_SCREENSHOT = PREFIX + ".action.request_screenshot";
@@ -57,6 +58,11 @@ public interface DeviceService extends EventHandler {
     String EXTRA_MUSIC_DURATION = "music_duration";
     String EXTRA_MUSIC_TRACKNR = "music_tracknr";
     String EXTRA_MUSIC_TRACKCOUNT = "music_trackcount";
+    String EXTRA_MUSIC_STATE = "music_state";
+    String EXTRA_MUSIC_SHUFFLE = "music_shuffle";
+    String EXTRA_MUSIC_REPEAT = "music_repeat";
+    String EXTRA_MUSIC_POSITION = "music_position";
+    String EXTRA_MUSIC_RATE = "music_rate";
     String EXTRA_APP_UUID = "app_uuid";
     String EXTRA_APP_START = "app_start";
     String EXTRA_APP_CONFIG = "app_config";

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/MusicStateSpec.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/MusicStateSpec.java
@@ -1,0 +1,12 @@
+package nodomain.freeyourgadget.gadgetbridge.model;
+
+/**
+ * Created by steffen on 07.06.16.
+ */
+public class MusicStateSpec {
+    public byte state;
+    public int position;
+    public int playRate;
+    public byte shuffle;
+    public byte repeat;
+}

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/MusicStateSpec.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/MusicStateSpec.java
@@ -4,6 +4,11 @@ package nodomain.freeyourgadget.gadgetbridge.model;
  * Created by steffen on 07.06.16.
  */
 public class MusicStateSpec {
+    public static final int STATE_PLAYING = 0;
+    public static final int STATE_PAUSED  = 1;
+    public static final int STATE_STOPPED = 2;
+    public static final int STATE_UNKNOWN = 3;
+
     public byte state;
     public int position;
     public int playRate;

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
@@ -38,6 +38,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.Alarm;
 import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationType;
 import nodomain.freeyourgadget.gadgetbridge.util.DeviceHelper;
@@ -65,6 +66,7 @@ import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.ACTION_RE
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.ACTION_REQUEST_DEVICEINFO;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.ACTION_REQUEST_SCREENSHOT;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.ACTION_SETMUSICINFO;
+import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.ACTION_SETMUSICSTATE;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.ACTION_SETTIME;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.ACTION_SET_ALARMS;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.ACTION_START;
@@ -87,6 +89,11 @@ import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_FIN
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_ALBUM;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_ARTIST;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_DURATION;
+import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_POSITION;
+import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_RATE;
+import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_REPEAT;
+import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_SHUFFLE;
+import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_STATE;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_TRACK;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_TRACKCOUNT;
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.EXTRA_MUSIC_TRACKNR;
@@ -350,6 +357,15 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 musicSpec.trackCount = intent.getIntExtra(EXTRA_MUSIC_TRACKCOUNT, 0);
                 musicSpec.trackNr = intent.getIntExtra(EXTRA_MUSIC_TRACKNR, 0);
                 mDeviceSupport.onSetMusicInfo(musicSpec);
+                break;
+            case ACTION_SETMUSICSTATE:
+                MusicStateSpec stateSpec = new MusicStateSpec();
+                stateSpec.shuffle = intent.getByteExtra(EXTRA_MUSIC_SHUFFLE, (byte)0);
+                stateSpec.repeat = intent.getByteExtra(EXTRA_MUSIC_REPEAT, (byte)0);
+                stateSpec.position = intent.getIntExtra(EXTRA_MUSIC_POSITION, 0);
+                stateSpec.playRate = intent.getIntExtra(EXTRA_MUSIC_RATE, 0);
+                stateSpec.state = intent.getByteExtra(EXTRA_MUSIC_STATE, (byte)0);
+                mDeviceSupport.onSetMusicState(stateSpec);
                 break;
             case ACTION_REQUEST_APPINFO:
                 mDeviceSupport.onAppInfoReq();

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/ServiceDeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/ServiceDeviceSupport.java
@@ -16,6 +16,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.Alarm;
 import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 
 /**
@@ -148,6 +149,14 @@ public class ServiceDeviceSupport implements DeviceSupport {
             return;
         }
         delegate.onSetCallState(callSpec);
+    }
+
+    @Override
+    public void onSetMusicState(MusicStateSpec stateSpec) {
+        if (checkBusy("set music state")) {
+            return;
+        }
+        delegate.onSetMusicState(stateSpec);
     }
 
     @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband/MiBandSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband/MiBandSupport.java
@@ -38,6 +38,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.DeviceService;
 import nodomain.freeyourgadget.gadgetbridge.model.GenericItem;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSupport;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.BtLEAction;
@@ -597,6 +598,11 @@ public class MiBandSupport extends AbstractBTLEDeviceSupport {
     private boolean isTelephoneRinging() {
         // don't synchronize, this is not really important
         return telephoneRinging;
+    }
+
+    @Override
+    public void onSetMusicState(MusicStateSpec stateSpec) {
+        // not supported
     }
 
     @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
@@ -35,6 +35,7 @@ import nodomain.freeyourgadget.gadgetbridge.impl.GBDeviceApp;
 import nodomain.freeyourgadget.gadgetbridge.model.ActivityUser;
 import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationType;
 import nodomain.freeyourgadget.gadgetbridge.service.serial.GBDeviceProtocol;
@@ -1102,6 +1103,20 @@ public class PebbleProtocol extends GBDeviceProtocol {
     }
 
     public byte[] encodeSetMusicState(byte state, int position, int playRate, byte shuffle, byte repeat) {
+        byte playState;
+
+        switch (state) {
+            case MusicStateSpec.STATE_PLAYING:
+                playState = MUSICCONTROL_STATE_PLAYING;
+                break;
+            case MusicStateSpec.STATE_PAUSED:
+                playState = MUSICCONTROL_STATE_PAUSED;
+                break;
+            default:
+                playState = MUSICCONTROL_STATE_UNKNOWN;
+                break;
+        }
+
         int length = LENGTH_PREFIX + 12;
         // Encode Prefix
         ByteBuffer buf = ByteBuffer.allocate(length);
@@ -1111,7 +1126,7 @@ public class PebbleProtocol extends GBDeviceProtocol {
 
         buf.order(ByteOrder.LITTLE_ENDIAN);
         buf.put(MUSICCONTROL_SETPLAYSTATE);
-        buf.put(state);
+        buf.put(playState);
         buf.putInt(position);
         buf.putInt(playRate);
         buf.put(shuffle);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
@@ -1159,7 +1159,7 @@ public class PebbleProtocol extends GBDeviceProtocol {
             }
 
             buf.order(ByteOrder.LITTLE_ENDIAN);
-            buf.putInt(duration * 1000);
+            buf.putInt(duration);
             buf.putShort((short) (trackCount & 0xffff));
             buf.putShort((short) (trackNr & 0xffff));
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
@@ -1159,7 +1159,7 @@ public class PebbleProtocol extends GBDeviceProtocol {
             }
 
             buf.order(ByteOrder.LITTLE_ENDIAN);
-            buf.putInt(duration);
+            buf.putInt(duration * 1000);
             buf.putShort((short) (trackCount & 0xffff));
             buf.putShort((short) (trackNr & 0xffff));
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
@@ -1126,7 +1126,6 @@ public class PebbleProtocol extends GBDeviceProtocol {
         if (duration == 0) {
             return encodeMessage(ENDPOINT_MUSICCONTROL, MUSICCONTROL_SETMUSICINFO, 0, parts);
         } else {
-            byte[] stateMessage = encodeSetMusicState(MUSICCONTROL_STATE_PLAYING, 0, 100, (byte) 1, (byte) 1);
             // Calculate length first
             int length = LENGTH_PREFIX + 9;
             if (parts != null) {
@@ -1140,7 +1139,7 @@ public class PebbleProtocol extends GBDeviceProtocol {
             }
 
             // Encode Prefix
-            ByteBuffer buf = ByteBuffer.allocate(length + stateMessage.length);
+            ByteBuffer buf = ByteBuffer.allocate(length);
             buf.order(ByteOrder.BIG_ENDIAN);
             buf.putShort((short) (length - LENGTH_PREFIX));
             buf.putShort(ENDPOINT_MUSICCONTROL);
@@ -1163,8 +1162,6 @@ public class PebbleProtocol extends GBDeviceProtocol {
             buf.putInt(duration * 1000);
             buf.putShort((short) (trackCount & 0xffff));
             buf.putShort((short) (trackNr & 0xffff));
-
-            buf.put(stateMessage);
 
             return buf.array();
         }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleSupport.java
@@ -15,6 +15,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.Alarm;
 import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 import nodomain.freeyourgadget.gadgetbridge.service.serial.AbstractSerialDeviceSupport;
 import nodomain.freeyourgadget.gadgetbridge.service.serial.GBDeviceIoThread;
@@ -105,6 +106,13 @@ public class PebbleSupport extends AbstractSerialDeviceSupport {
     public void onSetCallState(CallSpec callSpec) {
         if (reconnect()) {
             super.onSetCallState(callSpec);
+        }
+    }
+
+    @Override
+    public void onSetMusicState(MusicStateSpec musicStateSpec) {
+        if (reconnect()) {
+            super.onSetMusicState(musicStateSpec);
         }
     }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/serial/AbstractSerialDeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/serial/AbstractSerialDeviceSupport.java
@@ -11,6 +11,7 @@ import nodomain.freeyourgadget.gadgetbridge.devices.EventHandler;
 import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 import nodomain.freeyourgadget.gadgetbridge.service.AbstractDeviceSupport;
 
@@ -120,6 +121,12 @@ public abstract class AbstractSerialDeviceSupport extends AbstractDeviceSupport 
     @Override
     public void onSetCallState(CallSpec callSpec) {
         byte[] bytes = gbDeviceProtocol.encodeSetCallState(callSpec.number, callSpec.name, callSpec.command);
+        sendToDevice(bytes);
+    }
+
+    @Override
+    public void onSetMusicState(MusicStateSpec stateSpec) {
+        byte[] bytes = gbDeviceProtocol.encodeSetMusicState(stateSpec.state, stateSpec.position, stateSpec.playRate, stateSpec.shuffle, stateSpec.repeat);
         sendToDevice(bytes);
     }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/serial/GBDeviceProtocol.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/serial/GBDeviceProtocol.java
@@ -24,6 +24,10 @@ public abstract class GBDeviceProtocol {
         return null;
     }
 
+    public byte[] encodeSetMusicState(byte state, int position, int playRate, byte shuffle, byte repeat) {
+        return null;
+    }
+
     public byte[] encodeFirmwareVersionReq() {
         return null;
     }

--- a/app/src/test/java/nodomain/freeyourgadget/gadgetbridge/service/TestDeviceSupport.java
+++ b/app/src/test/java/nodomain/freeyourgadget/gadgetbridge/service/TestDeviceSupport.java
@@ -12,6 +12,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.Alarm;
 import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
+import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 
 public class TestDeviceSupport extends AbstractDeviceSupport {
@@ -63,6 +64,11 @@ public class TestDeviceSupport extends AbstractDeviceSupport {
 
     @Override
     public void onSetCallState(CallSpec callSpec) {
+
+    }
+
+    @Override
+    public void onSetMusicState(MusicStateSpec stateSpec) {
 
     }
 


### PR DESCRIPTION
PocketCasts tells about its current media state via notifications. This
patch tries to parse incoming notifications from PocketCasts and if
successful tells the device about it. Currently supported are track and
artist.

I tested this with my (original) pebble. I do not know if this can be enhanced with track lenght and current progress as I was not able to squeeze this info out of the notification. Also, the device setMusicInfo would have to be improved to set the current progress. Both should be possible as the pebble android app apparently can do that.