### PR TITLE
Revamp Notification types Pebble

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -23,20 +23,15 @@ import android.service.notification.StatusBarNotification;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.RemoteInput;
 import android.support.v4.content.LocalBroadcastManager;
-
+import nodomain.freeyourgadget.gadgetbridge.GBApplication;
+import nodomain.freeyourgadget.gadgetbridge.model.*;
+import nodomain.freeyourgadget.gadgetbridge.service.DeviceCommunicationService;
+import nodomain.freeyourgadget.gadgetbridge.util.LimitedQueue;
+import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-
-import nodomain.freeyourgadget.gadgetbridge.GBApplication;
-import nodomain.freeyourgadget.gadgetbridge.model.MusicSpec;
-import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
-import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
-import nodomain.freeyourgadget.gadgetbridge.model.NotificationType;
-import nodomain.freeyourgadget.gadgetbridge.service.DeviceCommunicationService;
-import nodomain.freeyourgadget.gadgetbridge.util.LimitedQueue;
-import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
 
 public class NotificationListener extends NotificationListenerService {
 
@@ -250,48 +245,7 @@ public class NotificationListener extends NotificationListenerService {
 
         boolean preferBigText = false;
 
-        switch (source) {
-            case "org.mariotaku.twidere":
-            case "com.twitter.android":
-            case "org.andstatus.app":
-            case "org.mustard.android":
-                notificationSpec.type = NotificationType.TWITTER;
-                break;
-            case "com.fsck.k9":
-            case "com.android.email":
-                notificationSpec.type = NotificationType.GENERIC_EMAIL;
-                preferBigText = true;
-                break;
-            case "com.moez.QKSMS":
-            case "com.android.mms":
-            case "com.android.messaging":
-            case "com.sonyericsson.conversations":
-            case "org.smssecure.smssecure":
-                notificationSpec.type = NotificationType.GENERIC_SMS;
-                break;
-            case "eu.siacs.conversations":
-                notificationSpec.type = NotificationType.CONVERSATIONS;
-                break;
-            case "org.thoughtcrime.securesms":
-                notificationSpec.type = NotificationType.SIGNAL;
-                break;
-            case "org.telegram.messenger":
-                notificationSpec.type = NotificationType.TELEGRAM;
-                break;
-            case "me.zeeroooo.materialfb":
-            case "it.rignanese.leo.slimfacebook":
-            case "me.jakelane.wrapperforfacebook":
-            case "com.facebook.katana":
-            case "org.indywidualni.fblite":
-                notificationSpec.type = NotificationType.FACEBOOK;
-                break;
-            case "com.facebook.orca":
-                notificationSpec.type = NotificationType.FACEBOOK_MESSENGER;
-                break;
-            default:
-                notificationSpec.type = NotificationType.UNKNOWN;
-                break;
-        }
+        notificationSpec.type = AppNotificationType.getInstance().get(source);
 
         LOG.info("Processing notification from source " + source);
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
@@ -21,7 +21,6 @@ public class AppNotificationType extends HashMap<String, NotificationType> {
 		
 		// Generic SMS
 		put("com.moez.QKSMS", NotificationType.GENERIC_SMS);
-		put("com.moez.QKSMS", NotificationType.GENERIC_SMS);
 		put("com.android.mms", NotificationType.GENERIC_SMS);
 		put("com.android.messaging", NotificationType.GENERIC_SMS);
 		put("com.sonyericsson.conversations", NotificationType.GENERIC_SMS);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
@@ -51,6 +51,9 @@ public class AppNotificationType extends HashMap<String, NotificationType> {
 
 		// Facebook Messenger
 		put("com.facebook.orca", NotificationType.FACEBOOK_MESSENGER);
+
+		// WhatsApp
+		put("com.whatsapp", NotificationType.WHATSAPP);
 	}
 
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
@@ -1,0 +1,56 @@
+package nodomain.freeyourgadget.gadgetbridge.model;
+
+import java.util.HashMap;
+
+public class AppNotificationType extends HashMap<String, NotificationType> {
+
+	private static AppNotificationType _instance;
+
+	public static AppNotificationType getInstance() {
+		if(_instance == null) {
+			return (_instance = new AppNotificationType());
+		}
+
+		return _instance;
+	}
+
+	private AppNotificationType() {
+		// Generic Email
+		put("com.fsck.k9", NotificationType.GENERIC_EMAIL);
+		put("com.android.email", NotificationType.GENERIC_EMAIL);
+		
+		// Generic SMS
+		put("com.moez.QKSMS", NotificationType.GENERIC_SMS);
+		put("com.moez.QKSMS", NotificationType.GENERIC_SMS);
+		put("com.android.mms", NotificationType.GENERIC_SMS);
+		put("com.android.messaging", NotificationType.GENERIC_SMS);
+		put("com.sonyericsson.conversations", NotificationType.GENERIC_SMS);
+		put("org.smssecure.smssecure", NotificationType.GENERIC_SMS);
+
+		// Conversations
+		put("eu.siacs.conversations", NotificationType.CONVERSATIONS);
+
+		// Signal
+		put("org.thoughtcrime.securesms", NotificationType.SIGNAL);
+
+		// Telegram
+		put("org.telegram.messenger", NotificationType.TELEGRAM);
+
+		// Twitter
+		put("org.mariotaku.twidere", NotificationType.TWITTER);
+		put("com.twitter.android", NotificationType.TWITTER);
+		put("org.andstatus.app", NotificationType.TWITTER);
+		put("org.mustard.android", NotificationType.TWITTER);
+		
+		// Facebook
+		put("me.zeeroooo.materialfb", NotificationType.FACEBOOK);
+		put("it.rignanese.leo.slimfacebook", NotificationType.FACEBOOK);
+		put("me.jakelane.wrapperforfacebook", NotificationType.FACEBOOK);
+		put("com.facebook.katana", NotificationType.FACEBOOK);
+		put("org.indywidualni.fblite", NotificationType.FACEBOOK);
+
+		// Facebook Messenger
+		put("com.facebook.orca", NotificationType.FACEBOOK_MESSENGER);
+	}
+
+}

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/NotificationType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/NotificationType.java
@@ -53,4 +53,4 @@ public enum NotificationType {
                 return "generic";
         }
     }
-    }
+}

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/NotificationType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/NotificationType.java
@@ -1,24 +1,34 @@
 package nodomain.freeyourgadget.gadgetbridge.model;
 
+import nodomain.freeyourgadget.gadgetbridge.devices.pebble.PebbleColor;
+import nodomain.freeyourgadget.gadgetbridge.devices.pebble.PebbleIconID;
+
 public enum NotificationType {
 
-    UNKNOWN,
+    UNKNOWN(PebbleIconID.NOTIFICATION_GENERIC, PebbleColor.Red),
 
-    CONVERSATIONS,
-    GENERIC_EMAIL,
-    GENERIC_NAVIGATION,
-    GENERIC_SMS,
-    FACEBOOK,
-    FACEBOOK_MESSENGER,
-    SIGNAL,
-    TWITTER,
-    TELEGRAM;
+    CONVERSATIONS(PebbleIconID.NOTIFICATION_HIPCHAT, PebbleColor.Inchworm),
+    GENERIC_EMAIL(PebbleIconID.GENERIC_EMAIL, PebbleColor.JaegerGreen),
+    GENERIC_NAVIGATION(PebbleIconID.LOCATION, PebbleColor.Orange),
+    GENERIC_SMS(PebbleIconID.GENERIC_SMS, PebbleColor.VividViolet),
+    FACEBOOK(PebbleIconID.NOTIFICATION_FACEBOOK, PebbleColor.Liberty),
+    FACEBOOK_MESSENGER(PebbleIconID.NOTIFICATION_FACEBOOK_MESSENGER, PebbleColor.VeryLightBlue),
+    SIGNAL(PebbleIconID.NOTIFICATION_HIPCHAT, PebbleColor.BlueMoon),
+    TWITTER(PebbleIconID.NOTIFICATION_TWITTER, PebbleColor.BlueMoon),
+    TELEGRAM(PebbleIconID.NOTIFICATION_TELEGRAM, PebbleColor.PictonBlue);
+
+    public int icon;
+    public byte color;
+
+    NotificationType(int icon, byte color) {
+        this.icon = icon;
+        this.color = color;
+    }
 
     /**
      * Returns the enum constant as a fixed String value, e.g. to be used
      * as preference key. In case the keys are ever changed, this method
      * may be used to bring backward compatibility.
-     * @return
      */
     public String getFixedValue() {
         return name().toLowerCase();
@@ -43,4 +53,4 @@ public enum NotificationType {
                 return "generic";
         }
     }
-}
+    }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/NotificationType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/NotificationType.java
@@ -15,7 +15,8 @@ public enum NotificationType {
     FACEBOOK_MESSENGER(PebbleIconID.NOTIFICATION_FACEBOOK_MESSENGER, PebbleColor.VeryLightBlue),
     SIGNAL(PebbleIconID.NOTIFICATION_HIPCHAT, PebbleColor.BlueMoon),
     TWITTER(PebbleIconID.NOTIFICATION_TWITTER, PebbleColor.BlueMoon),
-    TELEGRAM(PebbleIconID.NOTIFICATION_TELEGRAM, PebbleColor.PictonBlue);
+    TELEGRAM(PebbleIconID.NOTIFICATION_TELEGRAM, PebbleColor.PictonBlue),
+    WHATSAPP(PebbleIconID.NOTIFICATION_WHATSAPP, PebbleColor.MayGreen);
 
     public int icon;
     public byte color;
@@ -47,6 +48,7 @@ public enum NotificationType {
             case FACEBOOK_MESSENGER:
             case SIGNAL:
             case TELEGRAM:
+            case WHATSAPP:
                 return "generic_chat";
             case UNKNOWN:
             default:

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
@@ -814,6 +814,10 @@ public class PebbleProtocol extends GBDeviceProtocol {
 
         String[] parts = {title, subtitle, body};
 
+        if(notificationType == null) {
+            notificationType = NotificationType.UNKNOWN;
+        }
+
         int icon_id = notificationType.icon;
         byte color_id = notificationType.color;
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
@@ -2,7 +2,12 @@ package nodomain.freeyourgadget.gadgetbridge.service.devices.pebble;
 
 import android.util.Base64;
 import android.util.Pair;
-
+import nodomain.freeyourgadget.gadgetbridge.deviceevents.*;
+import nodomain.freeyourgadget.gadgetbridge.devices.pebble.PebbleIconID;
+import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
+import nodomain.freeyourgadget.gadgetbridge.impl.GBDeviceApp;
+import nodomain.freeyourgadget.gadgetbridge.model.*;
+import nodomain.freeyourgadget.gadgetbridge.service.serial.GBDeviceProtocol;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -11,35 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.SimpleTimeZone;
-import java.util.UUID;
-
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEvent;
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventAppInfo;
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventAppManagement;
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventAppMessage;
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventCallControl;
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventMusicControl;
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventNotificationControl;
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventScreenshot;
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventSendBytes;
-import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventVersionInfo;
-import nodomain.freeyourgadget.gadgetbridge.devices.pebble.PebbleColor;
-import nodomain.freeyourgadget.gadgetbridge.devices.pebble.PebbleIconID;
-import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
-import nodomain.freeyourgadget.gadgetbridge.impl.GBDeviceApp;
-import nodomain.freeyourgadget.gadgetbridge.model.ActivityUser;
-import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
-import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
-import nodomain.freeyourgadget.gadgetbridge.model.CannedMessagesSpec;
-import nodomain.freeyourgadget.gadgetbridge.model.MusicStateSpec;
-import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
-import nodomain.freeyourgadget.gadgetbridge.model.NotificationType;
-import nodomain.freeyourgadget.gadgetbridge.service.serial.GBDeviceProtocol;
+import java.util.*;
 
 public class PebbleProtocol extends GBDeviceProtocol {
 
@@ -828,7 +805,6 @@ public class PebbleProtocol extends GBDeviceProtocol {
             buf.put(subtitle.getBytes());
         }
 
-
         return encodeBlobdb(uuid, BLOBDB_INSERT, BLOBDB_PIN, buf.array());
     }
 
@@ -838,50 +814,9 @@ public class PebbleProtocol extends GBDeviceProtocol {
 
         String[] parts = {title, subtitle, body};
 
-        int icon_id;
-        byte color_id;
-        switch (notificationType) {
-            case CONVERSATIONS:
-                icon_id = PebbleIconID.NOTIFICATION_HIPCHAT;
-                color_id = PebbleColor.Inchworm;
-                break;
-            case GENERIC_EMAIL:
-                icon_id = PebbleIconID.GENERIC_EMAIL;
-                color_id = PebbleColor.JaegerGreen;
-                break;
-            case GENERIC_NAVIGATION:
-                icon_id = mFwMajor >= 4 ? PebbleIconID.NOTIFICATION_GOOGLE_MAPS : PebbleIconID.LOCATION;
-                color_id = PebbleColor.Orange;
-                break;
-            case GENERIC_SMS:
-                icon_id = PebbleIconID.GENERIC_SMS;
-                color_id = PebbleColor.VividViolet;
-                break;
-            case TWITTER:
-                icon_id = PebbleIconID.NOTIFICATION_TWITTER;
-                color_id = PebbleColor.BlueMoon;
-                break;
-            case FACEBOOK:
-                icon_id = PebbleIconID.NOTIFICATION_FACEBOOK;
-                color_id = PebbleColor.Liberty;
-                break;
-            case FACEBOOK_MESSENGER:
-                icon_id = PebbleIconID.NOTIFICATION_FACEBOOK_MESSENGER;
-                color_id = PebbleColor.VeryLightBlue;
-                break;
-            case TELEGRAM:
-                icon_id = PebbleIconID.NOTIFICATION_TELEGRAM;
-                color_id = PebbleColor.PictonBlue;
-                break;
-            case SIGNAL:
-                icon_id = PebbleIconID.NOTIFICATION_HIPCHAT;
-                color_id = PebbleColor.BlueMoon;
-                break;
-            default:
-                icon_id = PebbleIconID.NOTIFICATION_GENERIC;
-                color_id = PebbleColor.Red;
-                break;
-        }
+        int icon_id = notificationType.icon;
+        byte color_id = notificationType.color;
+
         // Calculate length first
         byte actions_count;
         short actions_length;


### PR DESCRIPTION
This PR moves the big switches that handle the notification types for Pebble to the existing `NotificationType` `enum` and an `AppNotificationType` class which is a singleton `HashMap`. 

I hope that this is will make it easier in the future to add support for new apps.

![photo_2016-12-08_19-22-40](https://cloud.githubusercontent.com/assets/1887585/21022116/b3047d86-bd7b-11e6-8dc1-cfdb7140f048.jpg)
