### PR TITLE
Set notification to minimal priority

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GB.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GB.java
@@ -61,6 +61,7 @@ public class GB {
                 .setContentText(text)
                 .setSmallIcon(connected ? R.drawable.ic_notification : R.drawable.ic_notification_disconnected)
                 .setContentIntent(pendingIntent)
+                .setPriority(Notification.PRIORITY_MIN)
                 .setOngoing(true);
         if (GBApplication.isRunningLollipopOrLater()) {
             builder.setVisibility(Notification.VISIBILITY_PUBLIC);


### PR DESCRIPTION
Pebble app is not showing in status bar and on lockscreen. This change is for GadgetBridge to have the same behavior.