### PR TITLE
Added (missing) battery status display feature for Mi Band 2 to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ####Version 0.15.1
 * Improved handling of notifications for some apps
 * Pebble 2/LE: Add setting to limit GATT MTU for debugging broken BLE stacks
+* Mi Band 2: Display battery status
 
 ####Version 0.15.0
 * New device: Liveview


### PR DESCRIPTION
The feature was not listed in the changelog. 0.15.1 is already released – not sure, if you want to add it afterwards, though...