### PR TITLE
Show K9 message body in notifications

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -252,6 +252,10 @@ public class NotificationListener extends NotificationListenerService {
 
         notificationSpec.type = AppNotificationType.getInstance().get(source);
 
+        if (source.equals("com.fsck.k9")) {
+            preferBigText = true;
+        }
+
         if (notificationSpec.type == null) {
             notificationSpec.type = NotificationType.UNKNOWN;
         }


### PR DESCRIPTION
K9 message body was not showing up in notifications since 0.15.0. This PR fixes that.