### PR TITLE
Transliterate unsupported Russian characters into English

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.4'
 
 //    compile project(":DaoCore")
+    compile 'com.google.guava:guava:19.0'
 }
 
 preBuild.dependsOn(":GBDaoGenerator:genSources")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,6 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.4'
 
 //    compile project(":DaoCore")
-    compile 'com.google.guava:guava:19.0'
 }
 
 preBuild.dependsOn(":GBDaoGenerator:genSources")

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
@@ -51,6 +51,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.WeatherSpec;
 import nodomain.freeyourgadget.gadgetbridge.util.DeviceHelper;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.GBPrefs;
+import nodomain.freeyourgadget.gadgetbridge.util.LanguageUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
 
 import static nodomain.freeyourgadget.gadgetbridge.model.DeviceService.ACTION_ADD_CALENDAREVENT;
@@ -322,21 +323,23 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 break;
             case ACTION_NOTIFICATION: {
                 NotificationSpec notificationSpec = new NotificationSpec();
-                notificationSpec.phoneNumber = intent.getStringExtra(EXTRA_NOTIFICATION_PHONENUMBER);
-                notificationSpec.sender = intent.getStringExtra(EXTRA_NOTIFICATION_SENDER);
-                notificationSpec.subject = intent.getStringExtra(EXTRA_NOTIFICATION_SUBJECT);
-                notificationSpec.title = intent.getStringExtra(EXTRA_NOTIFICATION_TITLE);
-                notificationSpec.body = intent.getStringExtra(EXTRA_NOTIFICATION_BODY);
+                notificationSpec.phoneNumber = getStringExtra(intent, EXTRA_NOTIFICATION_PHONENUMBER);
+                notificationSpec.sender = getStringExtra(intent, EXTRA_NOTIFICATION_SENDER);
+                notificationSpec.subject = getStringExtra(intent, EXTRA_NOTIFICATION_SUBJECT);
+                notificationSpec.title = getStringExtra(intent, EXTRA_NOTIFICATION_TITLE);
+                notificationSpec.body = getStringExtra(intent, EXTRA_NOTIFICATION_BODY);
+                notificationSpec.sourceName = getStringExtra(intent, EXTRA_NOTIFICATION_SOURCENAME);
                 notificationSpec.type = (NotificationType) intent.getSerializableExtra(EXTRA_NOTIFICATION_TYPE);
                 notificationSpec.id = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1);
                 notificationSpec.flags = intent.getIntExtra(EXTRA_NOTIFICATION_FLAGS, 0);
-                notificationSpec.sourceName = intent.getStringExtra(EXTRA_NOTIFICATION_SOURCENAME);
+
                 if (notificationSpec.type == NotificationType.GENERIC_SMS && notificationSpec.phoneNumber != null) {
                     notificationSpec.sender = getContactDisplayNameByNumber(notificationSpec.phoneNumber);
 
                     notificationSpec.id = mRandom.nextInt(); // FIXME: add this in external SMS Receiver?
                     GBApplication.getIDSenderLookup().add(notificationSpec.id, notificationSpec.phoneNumber);
                 }
+
                 if (((notificationSpec.flags & NotificationSpec.FLAG_WEARABLE_REPLY) > 0)
                         || (notificationSpec.type == NotificationType.GENERIC_SMS && notificationSpec.phoneNumber != null)) {
                     // NOTE: maybe not where it belongs
@@ -353,6 +356,7 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                         notificationSpec.cannedReplies = replies.toArray(new String[replies.size()]);
                     }
                 }
+
                 mDeviceSupport.onNotification(notificationSpec);
                 break;
             }
@@ -366,8 +370,8 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 calendarEventSpec.type = intent.getByteExtra(EXTRA_CALENDAREVENT_TYPE, (byte) -1);
                 calendarEventSpec.timestamp = intent.getIntExtra(EXTRA_CALENDAREVENT_TIMESTAMP, -1);
                 calendarEventSpec.durationInSeconds = intent.getIntExtra(EXTRA_CALENDAREVENT_DURATION, -1);
-                calendarEventSpec.title = intent.getStringExtra(EXTRA_CALENDAREVENT_TITLE);
-                calendarEventSpec.description = intent.getStringExtra(EXTRA_CALENDAREVENT_DESCRIPTION);
+                calendarEventSpec.title = getStringExtra(intent, EXTRA_CALENDAREVENT_TITLE);
+                calendarEventSpec.description = getStringExtra(intent, EXTRA_CALENDAREVENT_DESCRIPTION);
                 mDeviceSupport.onAddCalendarEvent(calendarEventSpec);
                 break;
             }
@@ -412,7 +416,7 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
             case ACTION_CALLSTATE:
                 int command = intent.getIntExtra(EXTRA_CALL_COMMAND, CallSpec.CALL_UNDEFINED);
 
-                String phoneNumber = intent.getStringExtra(EXTRA_CALL_PHONENUMBER);
+                String phoneNumber = getStringExtra(intent, EXTRA_CALL_PHONENUMBER);
                 String callerName = null;
                 if (phoneNumber != null) {
                     callerName = getContactDisplayNameByNumber(phoneNumber);
@@ -438,9 +442,9 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 break;
             case ACTION_SETMUSICINFO:
                 MusicSpec musicSpec = new MusicSpec();
-                musicSpec.artist = intent.getStringExtra(EXTRA_MUSIC_ARTIST);
-                musicSpec.album = intent.getStringExtra(EXTRA_MUSIC_ALBUM);
-                musicSpec.track = intent.getStringExtra(EXTRA_MUSIC_TRACK);
+                musicSpec.artist = getStringExtra(intent, EXTRA_MUSIC_ARTIST);
+                musicSpec.album = getStringExtra(intent, EXTRA_MUSIC_ALBUM);
+                musicSpec.track = getStringExtra(intent, EXTRA_MUSIC_TRACK);
                 musicSpec.duration = intent.getIntExtra(EXTRA_MUSIC_DURATION, 0);
                 musicSpec.trackCount = intent.getIntExtra(EXTRA_MUSIC_TRACKCOUNT, 0);
                 musicSpec.trackNr = intent.getIntExtra(EXTRA_MUSIC_TRACKNR, 0);
@@ -703,7 +707,18 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
             // ignore, just return name below
         }
 
-        return name;
+        return LanguageUtils.transliterate()
+                    ? LanguageUtils.transliterate(name)
+                    : name;
+    }
+
+    //Standard method with transliteration
+    private String getStringExtra(Intent intent, String event){
+        String extra = intent.getStringExtra(event);
+
+        return LanguageUtils.transliterate()
+                    ? LanguageUtils.transliterate(extra)
+                    : extra;
     }
 
     @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -785,7 +785,12 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
 
     //replace unsupported symbols to english analog
     private String transliterate(String txt){
+        if (txt == null || txt.isEmpty()) {
+            return txt;
+        }
+
         StringBuilder message = new StringBuilder();
+
         char[] chars = txt.toCharArray();
 
         for (char c : chars)

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -14,8 +14,6 @@ import android.net.Uri;
 import android.support.v4.content.LocalBroadcastManager;
 import android.widget.Toast;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +21,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
-import java.util.Map;
 import java.util.UUID;
 
 import nodomain.freeyourgadget.gadgetbridge.devices.hplus.HPlusConstants;
@@ -41,10 +38,10 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSuppo
 import nodomain.freeyourgadget.gadgetbridge.service.btle.GattService;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.actions.SetDeviceStateAction;
-import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.AbstractBleProfile;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfo;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfoProfile;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
+import nodomain.freeyourgadget.gadgetbridge.util.LanguageUtils;
 
 
 public class HPlusSupport extends AbstractBTLEDeviceSupport {
@@ -649,7 +646,10 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
     private void showIncomingCall(String name, String number) {
         try {
             TransactionBuilder builder = performInitialized("incomingCallIcon");
-            name = transliterate(name);
+
+            if (LanguageUtils.transliterate()) {
+                name = LanguageUtils.transliterate(name);
+            }
 
             //Enable call notifications
             builder.write(ctrlCharacteristic, new byte[]{HPlusConstants.CMD_ACTION_INCOMING_CALL, 1});
@@ -707,8 +707,11 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         LOG.debug("Show Notification: "+title+" --> "+body);
         try {
             TransactionBuilder builder = performInitialized("notification");
-            title = transliterate(title);
-            body = transliterate(body);
+
+            if (LanguageUtils.transliterate()) {
+                title = LanguageUtils.transliterate(title);
+                body = LanguageUtils.transliterate(body);
+            }
 
             byte[] msg = new byte[20];
             for (int i = 0; i < msg.length; i++)
@@ -781,54 +784,6 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
             syncHelper.quit();
             syncHelper = null;
         }
-    }
-
-    //replace unsupported symbols to english analog
-    private String transliterate(String txt){
-        if (txt == null || txt.isEmpty()) {
-            return txt;
-        }
-
-        StringBuilder message = new StringBuilder();
-
-        char[] chars = txt.toCharArray();
-
-        for (char c : chars)
-        {
-            message.append(transliterate(c));
-        }
-
-        return message.toString();
-    }
-
-    //replace unsupported symbol to english analog text
-    private String transliterate(char c){
-        Map<Character, String> map = ImmutableMap.<Character, String>builder()
-                .put('а', "a").put('б', "b").put('в', "v").put('г', "g")
-                .put('д', "d").put('е', "e").put('ё', "jo").put('ж', "zh")
-                .put('з', "z").put('и', "i").put('й', "jj").put('к', "k")
-                .put('л', "l").put('м', "m").put('н', "n").put('о', "o")
-                .put('п', "p").put('р', "r").put('с', "s").put('т', "t")
-                .put('у', "u").put('ф', "f").put('х', "kh").put('ц', "c")
-                .put('ч', "ch").put('ш', "sh").put('щ', "shh").put('ъ', "\"")
-                .put('ы', "y").put('ь', "'").put('э', "eh").put('ю', "ju")
-                .put('я', "ja")
-                .build();
-
-        char lowerChar = Character.toLowerCase(c);
-
-        if (map.containsKey(lowerChar)) {
-            String replace = map.get(lowerChar);
-
-            if (lowerChar != c)
-            {
-                return replace.toUpperCase();
-            }
-
-            return replace;
-        }
-
-        return String.valueOf(c);
     }
 
     @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -41,7 +41,6 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.actions.SetDeviceStateA
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfo;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfoProfile;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
-import nodomain.freeyourgadget.gadgetbridge.util.LanguageUtils;
 
 
 public class HPlusSupport extends AbstractBTLEDeviceSupport {
@@ -647,10 +646,6 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         try {
             TransactionBuilder builder = performInitialized("incomingCallIcon");
 
-            if (LanguageUtils.transliterate()) {
-                name = LanguageUtils.transliterate(name);
-            }
-
             //Enable call notifications
             builder.write(ctrlCharacteristic, new byte[]{HPlusConstants.CMD_ACTION_INCOMING_CALL, 1});
 
@@ -707,11 +702,6 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         LOG.debug("Show Notification: "+title+" --> "+body);
         try {
             TransactionBuilder builder = performInitialized("notification");
-
-            if (LanguageUtils.transliterate()) {
-                title = LanguageUtils.transliterate(title);
-                body = LanguageUtils.transliterate(body);
-            }
 
             byte[] msg = new byte[20];
             for (int i = 0; i < msg.length; i++)

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
@@ -10,7 +10,7 @@ public class LanguageUtils {
     private static Map<Character, String> transliterateMap = new HashMap<Character, String>(){
         {
             //extended ASCII characters
-            put('æ', "ae"); put('œ', "oe"); put('ß', "B");
+            put('æ', "ae"); put('œ', "oe"); put('ß', "B"); put('ª', "a"); put('º', "o");
 
             //russian chars
             put('а', "a"); put('б', "b"); put('в', "v");  put('г', "g"); put('д', "d"); put('е', "e"); put('ё', "jo"); put('ж', "zh");
@@ -67,13 +67,7 @@ public class LanguageUtils {
 
     //convert diacritic
     private static String flattenToAscii(String string) {
-        char[] out = new char[string.length()];
         string = Normalizer.normalize(string, Normalizer.Form.NFD);
-        int j = 0;
-        for (int i = 0, n = string.length(); i < n; ++i) {
-            char c = string.charAt(i);
-            if (c <= '\u007F') out[j++] = c;
-        }
-        return new String(out);
+        return string.replaceAll("\\p{M}", "");
     }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
@@ -10,7 +10,7 @@ public class LanguageUtils {
     private static Map<Character, String> transliterateMap = new HashMap<Character, String>(){
         {
             //extended ASCII characters
-            put('æ', "ae"); put('œ', "oe"); put('ß', "B"); put('ª', "a"); put('º', "o");
+            put('æ', "ae"); put('œ', "oe"); put('ß', "B"); put('ª', "a"); put('º', "o"); put('«',"\""); put('»',"\"");
 
             //russian chars
             put('а', "a"); put('б', "b"); put('в', "v");  put('г', "g"); put('д', "d"); put('е', "e"); put('ё', "jo"); put('ж', "zh");

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
@@ -26,7 +26,7 @@ public class LanguageUtils {
     //check transliterate option status
     public static boolean transliterate()
     {
-        return GBApplication.getPrefs().getBoolean("transliteration", true);
+        return GBApplication.getPrefs().getBoolean("transliteration", false);
     }
 
     //replace unsupported symbols to english analog

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
@@ -1,0 +1,64 @@
+package nodomain.freeyourgadget.gadgetbridge.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import nodomain.freeyourgadget.gadgetbridge.GBApplication;
+
+public class LanguageUtils {
+    //transliteration map with english equivalent for unsupported chars
+    private static Map<Character, String> transliterateMap = new HashMap<Character, String>(){
+        {
+            //russian chars
+            put('а', "a"); put('б', "b"); put('в', "v");  put('г', "g"); put('д', "d"); put('е', "e"); put('ё', "jo"); put('ж', "zh");
+            put('з', "z"); put('и', "i"); put('й', "jj"); put('к', "k"); put('л', "l"); put('м', "m"); put('н', "n");  put('о', "o");
+            put('п', "p"); put('р', "r"); put('с', "s");  put('т', "t"); put('у', "u"); put('ф', "f"); put('х', "kh"); put('ц', "c");
+            put('ч', "ch");put('ш', "sh");put('щ', "shh");put('ъ', "\"");put('ы', "y"); put('ь', "'"); put('э', "eh"); put('ю', "ju");
+            put('я', "ja");
+
+            //continue for other languages...
+        }
+    };
+
+    //check transliterate option status
+    public static boolean transliterate()
+    {
+        return GBApplication.getPrefs().getBoolean("transliteration", true);
+    }
+
+    //replace unsupported symbols to english analog
+    public static String transliterate(String txt){
+        if (txt == null || txt.isEmpty()) {
+            return txt;
+        }
+
+        StringBuilder message = new StringBuilder();
+
+        char[] chars = txt.toCharArray();
+
+        for (char c : chars)
+        {
+            message.append(transliterate(c));
+        }
+
+        return message.toString();
+    }
+
+    //replace unsupported symbol to english analog text
+    private static String transliterate(char c){
+        char lowerChar = Character.toLowerCase(c);
+
+        if (transliterateMap.containsKey(lowerChar)) {
+            String replace = transliterateMap.get(lowerChar);
+
+            if (lowerChar != c)
+            {
+                return replace.toUpperCase();
+            }
+
+            return replace;
+        }
+
+        return String.valueOf(c);
+    }
+}

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
@@ -2,13 +2,16 @@ package nodomain.freeyourgadget.gadgetbridge.util;
 
 import java.util.HashMap;
 import java.util.Map;
-
+import java.text.Normalizer;
 import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 
 public class LanguageUtils {
     //transliteration map with english equivalent for unsupported chars
     private static Map<Character, String> transliterateMap = new HashMap<Character, String>(){
         {
+            //extended ASCII characters
+            put('æ', "ae"); put('œ', "oe"); put('ß', "B");
+
             //russian chars
             put('а', "a"); put('б', "b"); put('в', "v");  put('г', "g"); put('д', "d"); put('е', "e"); put('ё', "jo"); put('ж', "zh");
             put('з', "z"); put('и', "i"); put('й', "jj"); put('к', "k"); put('л', "l"); put('м', "m"); put('н', "n");  put('о', "o");
@@ -41,7 +44,7 @@ public class LanguageUtils {
             message.append(transliterate(c));
         }
 
-        return message.toString();
+        return flattenToAscii(message.toString());
     }
 
     //replace unsupported symbol to english analog text
@@ -60,5 +63,17 @@ public class LanguageUtils {
         }
 
         return String.valueOf(c);
+    }
+
+    //convert diacritic
+    private static String flattenToAscii(String string) {
+        char[] out = new char[string.length()];
+        string = Normalizer.normalize(string, Normalizer.Form.NFD);
+        int j = 0;
+        for (int i = 0, n = string.length(); i < n; ++i) {
+            char c = string.charAt(i);
+            if (c <= '\u007F') out[j++] = c;
+        }
+        return new String(out);
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -52,6 +52,8 @@
   <string name="pref_title_whenscreenon">… даже когда экран включён</string>
   <string name="pref_title_notification_filter">Не беспокоить</string>
   <string name="pref_summary_notification_filter">Предотвращать отправку нежелательных уведомлений в режиме \"Не беспокоить\"</string>
+  <string name="pref_title_transliteration">Транслитерация</string>
+  <string name="pref_summary_transliteration">Используйте, если устройство не может работать с вашим языком</string>
   <string name="always">всегда</string>
   <string name="when_screen_off">когда экран выключен</string>
   <string name="never">никогда</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,8 @@
     <string name="pref_title_whenscreenon">… also when screen is on</string>
     <string name="pref_title_notification_filter">Do Not Disturb</string>
     <string name="pref_summary_notification_filter">Stop unwanted Notifications from being sent based on the Do Not Disturb mode.</string>
+    <string name="pref_title_transliteration">Transliteration</string>
+    <string name="pref_summary_transliteration">Use, if the device can not work with your language</string>
 
     <string name="always">always</string>
     <string name="when_screen_off">when screen is off</string>

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,7 +2,7 @@
 <changelog>
     <release version="0.17.0" versioncode="81">
         <change>Add weather support through "Weather Notification" app</change>
-	    <change>Various fixes for K9 mail when using the generic notification receiver</change>
+        <change>Various fixes for K9 mail when using the generic notification receiver</change>
         <change>Added transliteration option for notifications in the settings screen</change>
         <change>Add a preference to hide the notification icon of Gadgetbridge</change>
 

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -3,7 +3,8 @@
     <release version="0.17.0" versioncode="81">
         <change>Add weather support through "Weather Notification" app</change>
         <change>Various fixes for K9 mail when using the generic notification receiver</change>
-        <change>Added transliteration option for notifications in the settings screen</change>
+        <change>Added transliteration support for Russian characters into English</change>
+        <change>Added transliteration option in the settings screen</change>
         <change>Add a preference to hide the notification icon of Gadgetbridge</change>
 
         <change>Pebble: Support for build-in weather system app (FW 4.x)</change>
@@ -19,7 +20,6 @@
         <change>HPlus: Near real time Heart rate measurement</change>
         <change>HPlus: Experimental synchronization of activity data (only sleep, steps and intensity)</change>
         <change>HPlus: Fix some disconnection issues</change>
-        <change>HPlus: Transliterate unsupported Russian characters into English</change>
     </release>
     <release version="0.16.0" versioncode="80">
         <change>New devices: HPlus (e.g. Zeblaze ZeBand), contributed by João Paulo Barraca</change>

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,7 +2,8 @@
 <changelog>
     <release version="0.17.0" versioncode="81">
         <change>Add weather support through "Weather Notification" app</change>
-	<change>Various fixes for K9 mail when using the generic notification receiver</change>
+	    <change>Various fixes for K9 mail when using the generic notification receiver</change>
+        <change>Added transliteration option for notifications in the settings screen</change>
         <change>Pebble: Support for build-in weather system app (FW 4.x)</change>
         <change>Pebble: Add weather support for various watchfaces</change>
         <change>Pebble: Delete notifications that got dismissed on the phone</change>

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -16,6 +16,7 @@
         <change>HPlus: Near real time Heart rate measurement</change>
         <change>HPlus: Experimental synchronization of activity data (only sleep, steps and intensity)</change>
         <change>HPlus: Fix some disconnection issues</change>
+        <change>HPlus: Transliterate unsupported Russian characters into English</change>
     </release>
     <release version="0.16.0" versioncode="80">
         <change>New devices: HPlus (e.g. Zeblaze ZeBand), contributed by João Paulo Barraca</change>

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,7 +2,7 @@
 <changelog>
     <release version="0.17.0" versioncode="81">
         <change>Add weather support through "Weather Notification" app</change>
-	 <change>Various fixes for K9 mail when using the generic notification receiver</change>
+	    <change>Various fixes for K9 mail when using the generic notification receiver</change>
         <change>Added transliteration option for notifications in the settings screen</change>
         <change>Add a preference to hide the notification icon of Gadgetbridge</change>
 

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,7 +2,7 @@
 <changelog>
     <release version="0.17.0" versioncode="81">
         <change>Add weather support through "Weather Notification" app</change>
-	      <change>Various fixes for K9 mail when using the generic notification receiver</change>
+	 <change>Various fixes for K9 mail when using the generic notification receiver</change>
         <change>Added transliteration option for notifications in the settings screen</change>
         <change>Add a preference to hide the notification icon of Gadgetbridge</change>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -93,6 +93,13 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
+            android:key="transliteration"
+            android:summary="@string/pref_summary_transliteration"
+            android:title="@string/pref_title_transliteration"
+            />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
             android:key="notification_filter"
             android:summary="@string/pref_summary_notification_filter"
             android:title="@string/pref_title_notification_filter" />


### PR DESCRIPTION
Zeblaze ZeBand don't support russian language, so i found the great solution. Just transliterated to eng unsupported chars. Other symbols are not affected.

Method can be extended for other languages, it's very easy.