### PR TITLE
HPlus: Improve display of new messages and phone calls

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusConstants.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusConstants.java
@@ -4,6 +4,8 @@ package nodomain.freeyourgadget.gadgetbridge.devices.hplus;
 * @author João Paulo Barraca &lt;jpbarraca@gmail.com&gt;
 */
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 public final class HPlusConstants {
@@ -110,4 +112,61 @@ public final class HPlusConstants {
     public static final String PREF_HPLUS_SIT_START_TIME = "hplus_sit_start_time";
     public static final String PREF_HPLUS_SIT_END_TIME = "hplus_sit_end_time";
     public static final String PREF_HPLUS_COUNTRY = "hplus_country";
+
+    public static final Map<Character, Byte> transliterateMap = new HashMap<Character, Byte>(){
+        {
+            //These are missing
+            put('ó', new Byte((byte) 111));
+            put('Ó', new Byte((byte) 79));
+            put('í', new Byte((byte) 105));
+            put('Í', new Byte((byte) 73));
+            put('ú', new Byte((byte) 117));
+            put('Ú', new Byte((byte) 85));
+
+            //These mostly belong to the extended ASCII table
+            put('Ç', new Byte((byte) 128));
+            put('ü', new Byte((byte) 129));
+            put('é', new Byte((byte) 130));
+            put('â', new Byte((byte) 131));
+            put('ä', new Byte((byte) 132));
+            put('à', new Byte((byte) 133));
+            put('ã', new Byte((byte) 134));
+            put('ç', new Byte((byte) 135));
+            put('ê', new Byte((byte) 136));
+            put('ë', new Byte((byte) 137));
+            put('è', new Byte((byte) 138));
+            put('Ï', new Byte((byte) 139));
+            put('Î', new Byte((byte) 140));
+            put('Ì', new Byte((byte) 141));
+            put('Ã', new Byte((byte) 142));
+            put('Ä', new Byte((byte) 143));
+            put('É', new Byte((byte) 144));
+            put('æ', new Byte((byte) 145));
+            put('Æ', new Byte((byte) 146));
+            put('ô', new Byte((byte) 147));
+            put('ö', new Byte((byte) 148));
+            put('ò', new Byte((byte) 149));
+            put('û', new Byte((byte) 150));
+            put('ù', new Byte((byte) 151));
+            put('ÿ', new Byte((byte) 152));
+            put('Ö', new Byte((byte) 153));
+            put('Ü', new Byte((byte) 154));
+            put('¢', new Byte((byte) 155));
+            put('£', new Byte((byte) 156));
+            put('¥', new Byte((byte) 157));
+            put('ƒ', new Byte((byte) 159));
+            put('á', new Byte((byte) 160));
+            put('ñ', new Byte((byte) 164));
+            put('Ñ', new Byte((byte) 165));
+            put('ª', new Byte((byte) 166));
+            put('º', new Byte((byte) 167));
+            put('¿', new Byte((byte) 168));
+            put('¬', new Byte((byte) 170));
+            put('½', new Byte((byte) 171));
+            put('¼', new Byte((byte) 172));
+            put('¡', new Byte((byte) 173));
+            put('«', new Byte((byte) 174));
+            put('»', new Byte((byte) 175));
+        }
+    };
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -44,7 +44,6 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.actions.SetDeviceStateA
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfo;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfoProfile;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
-import nodomain.freeyourgadget.gadgetbridge.util.LanguageUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.StringUtils;
 
 
@@ -677,10 +676,6 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
             for (int i = 0; i < msg.length; i++)
                 msg[i] = ' ';
 
-            if(LanguageUtils.transliterate()) {
-                name = LanguageUtils.transliterate(name);
-            }
-
             byte[] nameBytes = encodeStringToDevice(name);
             for (int i = 0; i < nameBytes.length && i < (msg.length - 1); i++)
                 msg[i + 1] = nameBytes[i];
@@ -706,18 +701,10 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
             String message = "";
 
             if (title != null && title.length() > 0) {
-
-                if(LanguageUtils.transliterate()){
-                    title = LanguageUtils.transliterate(title);
-                }
                 message = StringUtils.pad(StringUtils.truncate(title, 16), 16); //Limit title to top row
             }
 
             if(body != null) {
-                if(LanguageUtils.transliterate()){
-                    body = LanguageUtils.transliterate(body);
-                }
-
                 message += body;
             }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/StringUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/StringUtils.java
@@ -1,0 +1,25 @@
+package nodomain.freeyourgadget.gadgetbridge.util;
+
+public class StringUtils {
+
+    public static String truncate(String s, int maxLength){
+        int length = Math.min(s.length(), maxLength);
+
+        if(length < 0)
+            return "";
+
+        return s.substring(0, length);
+    }
+
+    public static String pad(String s, int length){
+        return pad(s, length, ' ');
+    }
+
+    public static String pad(String s, int length, char padChar){
+
+        while(s.length() < length)
+            s += padChar;
+
+        return s;
+    }
+}


### PR DESCRIPTION
The Zeband supports a subset of the GB2312, with some changes (may still require further research):
* up to char 175 it seems to use ASCII/Extended ASCII
* chars 161-163, 169, and 176-247 give access to the GB2312 table and the device will process two bytes at once. It means that there are many accented and special characters. Cyrillic is missing...

This pull request improves text display by: 
* incorporating the Transliteration work recently introduced.
* adjusting the remaining latin characters as some are still present. Because the transliteration table is specific for this device, it was not added to the LanguageUtils (alternative solutions are welcome). The result is that Cyrillic and accented Latin characters will be (mostly) displayed properly.
*  Improving Message notification display: Notifications start by displaying a message icon and then the message itself. The message title will take the top row, while the body will take the bottom row of the display. The title is truncated (usually app name or contact name), while the body is displayed completely using multiple screens, but up to 127 screens.
* Improving Phonecall notification display: Call notifications start by displaying a call icon, the phone number, and then the caller name in the center of the screen.
* Reducing notification latency by using a single transaction for each notification type.


