### PR TITLE
HPlus: Support for Makibes F68

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusConstants.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusConstants.java
@@ -15,8 +15,8 @@ public final class HPlusConstants {
     public static final UUID UUID_SERVICE_HP = UUID.fromString("14701820-620a-3973-7c78-9cfff0876abd");
 
 
-    public static final byte ARG_COUNTRY_CN = 1;
-    public static final byte ARG_COUNTRY_OTHER = 2;
+    public static final byte ARG_LANGUAGE_CN = 1;
+    public static final byte ARG_LANGUAGE_EN = 2;
 
     public static final byte ARG_TIMEMODE_24H = 0;
     public static final byte ARG_TIMEMODE_12H = 1;
@@ -111,7 +111,7 @@ public final class HPlusConstants {
     public static final String PREF_HPLUS_ALERT_TIME = "hplus_alert_time";
     public static final String PREF_HPLUS_SIT_START_TIME = "hplus_sit_start_time";
     public static final String PREF_HPLUS_SIT_END_TIME = "hplus_sit_end_time";
-    public static final String PREF_HPLUS_COUNTRY = "hplus_country";
+    public static final String PREF_HPLUS_LANGUAGE = "hplus_language";
 
     public static final Map<Character, Byte> transliterateMap = new HashMap<Character, Byte>(){
         {

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusCoordinator.java
@@ -38,8 +38,8 @@ import java.util.Collection;
 import java.util.Collections;
 
 public class HPlusCoordinator extends AbstractDeviceCoordinator {
-    private static final Logger LOG = LoggerFactory.getLogger(HPlusCoordinator.class);
-    private static Prefs prefs  = GBApplication.getPrefs();
+    protected static final Logger LOG = LoggerFactory.getLogger(HPlusCoordinator.class);
+    protected static Prefs prefs  = GBApplication.getPrefs();
 
     @NonNull
     @Override
@@ -144,8 +144,8 @@ public class HPlusCoordinator extends AbstractDeviceCoordinator {
         return activityUser.getStepsGoal();
     }
 
-    public static byte getCountry(String address) {
-        return (byte) prefs.getInt(HPlusConstants.PREF_HPLUS_COUNTRY + "_" + address, 10);
+    public static byte getLanguage(String address) {
+        return (byte) prefs.getInt(HPlusConstants.PREF_HPLUS_LANGUAGE + "_" + address, HPlusConstants.ARG_LANGUAGE_EN);
 
     }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/MakibesF68Coordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/MakibesF68Coordinator.java
@@ -1,0 +1,33 @@
+package nodomain.freeyourgadget.gadgetbridge.devices.hplus;
+
+/*
+* @author João Paulo Barraca &lt;jpbarraca@gmail.com&gt;
+*/
+
+
+import android.support.annotation.NonNull;
+
+import nodomain.freeyourgadget.gadgetbridge.impl.GBDeviceCandidate;
+import nodomain.freeyourgadget.gadgetbridge.model.DeviceType;
+
+/**
+ * Pseudo Coordinator for the Makibes F68, a sub type of the HPLUS devices
+ */
+public class MakibesF68Coordinator extends HPlusCoordinator {
+
+    @NonNull
+    @Override
+    public DeviceType getSupportedType(GBDeviceCandidate candidate) {
+        String name = candidate.getDevice().getName();
+        if(name != null && name.startsWith("SPORT")){
+            return DeviceType.MAKIBESF68;
+        }
+
+        return DeviceType.UNKNOWN;
+    }
+
+    @Override
+    public DeviceType getDeviceType() {
+        return DeviceType.MAKIBESF68;
+    }
+}

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/DeviceType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/DeviceType.java
@@ -14,6 +14,7 @@ public enum DeviceType {
     VIBRATISSIMO(20),
     LIVEVIEW(30),
     HPLUS(40),
+    MAKIBESF68(50),
     TEST(1000);
 
     private final int key;

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceSupportFactory.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceSupportFactory.java
@@ -10,6 +10,7 @@ import java.util.EnumSet;
 import nodomain.freeyourgadget.gadgetbridge.GBException;
 import nodomain.freeyourgadget.gadgetbridge.R;
 import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
+import nodomain.freeyourgadget.gadgetbridge.model.DeviceType;
 import nodomain.freeyourgadget.gadgetbridge.service.devices.liveview.LiveviewSupport;
 import nodomain.freeyourgadget.gadgetbridge.service.devices.miband2.MiBand2Support;
 import nodomain.freeyourgadget.gadgetbridge.service.devices.miband.MiBandSupport;
@@ -98,7 +99,10 @@ public class DeviceSupportFactory {
                         deviceSupport = new ServiceDeviceSupport(new LiveviewSupport(), EnumSet.of(ServiceDeviceSupport.Flags.BUSY_CHECKING));
                         break;
                     case HPLUS:
-                        deviceSupport = new ServiceDeviceSupport(new HPlusSupport(), EnumSet.of(ServiceDeviceSupport.Flags.BUSY_CHECKING));
+                        deviceSupport = new ServiceDeviceSupport(new HPlusSupport(DeviceType.HPLUS), EnumSet.of(ServiceDeviceSupport.Flags.BUSY_CHECKING));
+                        break;
+                    case MAKIBESF68:
+                        deviceSupport = new ServiceDeviceSupport(new HPlusSupport(DeviceType.MAKIBESF68), EnumSet.of(ServiceDeviceSupport.Flags.BUSY_CHECKING));
                         break;
                 }
                 if (deviceSupport != null) {

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusDataRecordDaySlot.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusDataRecordDaySlot.java
@@ -8,7 +8,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 
-import nodomain.freeyourgadget.gadgetbridge.model.ActivityKind;
+import nodomain.freeyourgadget.gadgetbridge.model.ActivitySample;
 
 
 public class HPlusDataRecordDaySlot extends HPlusDataRecord {
@@ -47,9 +47,9 @@ public class HPlusDataRecordDaySlot extends HPlusDataRecord {
         heartRate = data[1] & 0xFF;
 
         if(heartRate == 255 || heartRate == 0)
-            heartRate = ActivityKind.TYPE_NOT_MEASURED;
+            heartRate = ActivitySample.NOT_MEASURED;
 
-        steps = (data[2] & 0xFF) * 256 + data[3] & 0xFF;
+        steps = (data[2] & 0xFF) * 256 + (data[3] & 0xFF);
 
         //?? data[6]; atemp?? always 0
         secondsInactive = data[7] & 0xFF; // ?
@@ -69,16 +69,21 @@ public class HPlusDataRecordDaySlot extends HPlusDataRecord {
         return String.format(Locale.US, "Slot: %d, Time: %s, Steps: %d, InactiveSeconds: %d, HeartRate: %d", slot, slotTime.getTime(), steps, secondsInactive, heartRate);
     }
 
-    public void add(HPlusDataRecordDaySlot other){
+    public void accumulate(HPlusDataRecordDaySlot other){
         if(other == null)
             return;
 
-        steps += other.steps;
-        secondsInactive += other.secondsInactive;
-        if(heartRate == -1)
+        if(steps == ActivitySample.NOT_MEASURED)
+            steps = other.steps;
+        else if(other.steps != ActivitySample.NOT_MEASURED)
+            steps += other.steps;
+
+        if(heartRate == ActivitySample.NOT_MEASURED)
             heartRate = other.heartRate;
-        else if(other.heartRate != -1) {
+        else if(other.heartRate != ActivitySample.NOT_MEASURED) {
             heartRate = (heartRate + other.heartRate) / 2;
         }
+
+        secondsInactive += other.secondsInactive;
     }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusDataRecordRealtime.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusDataRecordRealtime.java
@@ -60,8 +60,8 @@ class HPlusDataRecordRealtime extends HPlusDataRecord {
         timestamp = (int) (GregorianCalendar.getInstance().getTimeInMillis() / 1000);
         distance = 10 * ((data[4] & 0xFF) * 256 + (data[3] & 0xFF)); // meters
         steps = (data[2] & 0xFF) * 256 + (data[1] & 0xFF);
-        int x = (data[6] & 0xFF) * 256 + data[5] & 0xFF;
-        int y = (data[8] & 0xFF) * 256 + data[7] & 0xFF;
+        int x = (data[6] & 0xFF) * 256 + (data[5] & 0xFF);
+        int y = (data[8] & 0xFF) * 256 + (data[7] & 0xFF);
 
         battery = data[9];
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/DeviceHelper.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/DeviceHelper.java
@@ -23,6 +23,7 @@ import nodomain.freeyourgadget.gadgetbridge.database.DBHelper;
 import nodomain.freeyourgadget.gadgetbridge.devices.DeviceCoordinator;
 import nodomain.freeyourgadget.gadgetbridge.devices.UnknownDeviceCoordinator;
 import nodomain.freeyourgadget.gadgetbridge.devices.hplus.HPlusCoordinator;
+import nodomain.freeyourgadget.gadgetbridge.devices.hplus.MakibesF68Coordinator;
 import nodomain.freeyourgadget.gadgetbridge.devices.liveview.LiveviewCoordinator;
 import nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBand2Coordinator;
 import nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandConst;
@@ -172,6 +173,8 @@ public class DeviceHelper {
         result.add(new VibratissimoCoordinator());
         result.add(new LiveviewCoordinator());
         result.add(new HPlusCoordinator());
+        result.add(new MakibesF68Coordinator());
+
         return result;
     }
 


### PR DESCRIPTION
Adds support for the Makibes F68 Watch.
This is a subset of the HPlus devices with small changes. Most of the HPlus code is reused, with changes to consider both currently tested devices (Zeband and F68). There was some refactoring of existing code as my knowledge of the HPlus devices increased.

In both devices, if Continuous Heart Rate monitoring is not active, Activity Statistics will miss data. This will be addressed but I feel the code is ready for more testing as it enables these devices to connect.
