### PR TITLE
Transliteration: capitalized just the first letter in the replacement

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
@@ -1,5 +1,7 @@
 package nodomain.freeyourgadget.gadgetbridge.util;
 
+import org.apache.commons.lang3.text.WordUtils;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.text.Normalizer;
@@ -67,7 +69,7 @@ public class LanguageUtils {
 
             if (lowerChar != c)
             {
-                return replace.toUpperCase();
+                return WordUtils.capitalize(replace);
             }
 
             return replace;


### PR DESCRIPTION
Small fix to upper case scenario:

old variant:    "Щавелевый суп" > "SHHavelevyjj sup"
fixed variant: "Щавелевый суп" > "Shhavelevyjj sup"