### PR TITLE
HPlus: Clear alarms before trying to set them

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusConstants.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusConstants.java
@@ -27,6 +27,8 @@ public final class HPlusConstants {
     public static final byte ARG_GENDER_MALE = 0;
     public static final byte ARG_GENDER_FEMALE = 1;
 
+    public static final byte ARG_ALARM_DISABLE = (byte) -1;
+
     public static final byte ARG_HEARTRATE_MEASURE_ON = 11;
     public static final byte ARG_HEARTRATE_MEASURE_OFF = 22;
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -432,6 +432,13 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         if (alarms.size() == 0)
             return;
 
+        Calendar t = GregorianCalendar.getInstance();
+        t.set(0, 0, 0, 0, HPlusConstants.ARG_ALARM_DISABLE, HPlusConstants.ARG_ALARM_DISABLE);
+
+        TransactionBuilder builder = new TransactionBuilder("alarm");
+        //Clear all alarms
+        setAlarm(builder, t);
+
         for (Alarm alarm : alarms) {
 
             if (!alarm.isEnabled())
@@ -440,8 +447,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
             if (alarm.isSmartWakeup()) //Not available
                 continue;
 
-            Calendar t = alarm.getAlarmCal();
-            TransactionBuilder builder = new TransactionBuilder("alarm");
+            t = alarm.getAlarmCal();
             setAlarm(builder, t);
             builder.queue(getQueue());
 


### PR DESCRIPTION
Reset the alarms set to the device before trying to set them.

If no alarm is compatible with the device, without this PR, the previous alarm would still be set.
