### PR TITLE
Update HPlusSupport.java, Swap day and month

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -199,8 +199,8 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
                 HPlusConstants.CMD_SET_DATE,
                 (byte) ((year / 256) & 0xff),
                 (byte) (year % 256),
-                (byte) (month + 1),
-                (byte) (day)
+                (byte) (day),
+                (byte) (month + 1)
 
         });
         return this;


### PR DESCRIPTION
I have swap day and month because it is more logical to ready first the day and then the month. Plus the day would be with bold and will be the first thing that you will check.