### PR TITLE
Swap deep and light sleep colours in charts

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/AbstractChartFragment.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/AbstractChartFragment.java
@@ -182,9 +182,9 @@ public abstract class AbstractChartFragment extends AbstractGBFragment {
         HEARTRATE_FILL_COLOR = ContextCompat.getColor(getContext(), R.color.chart_heartrate_fill);
         getContext().getTheme().resolveAttribute(R.attr.chart_activity, runningColor, true);
         AK_ACTIVITY_COLOR = runningColor.data;
-        getContext().getTheme().resolveAttribute(R.attr.chart_light_sleep, runningColor, true);
-        AK_DEEP_SLEEP_COLOR = runningColor.data;
         getContext().getTheme().resolveAttribute(R.attr.chart_deep_sleep, runningColor, true);
+        AK_DEEP_SLEEP_COLOR = runningColor.data;
+        getContext().getTheme().resolveAttribute(R.attr.chart_light_sleep, runningColor, true);
         AK_LIGHT_SLEEP_COLOR = runningColor.data;
         getContext().getTheme().resolveAttribute(R.attr.chart_not_worn, runningColor, true);
         AK_NOT_WORN_COLOR = runningColor.data;


### PR DESCRIPTION
This partially "fixes" issue #442. The effect of the change is
purely cosmetic: deep sleep is (once again) dark blue, light sleep
is (once again) light blue.