### PR TITLE
HPlus: Improve connection process

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusCoordinator.java
@@ -81,6 +81,11 @@ public class HPlusCoordinator extends AbstractDeviceCoordinator {
     }
 
     @Override
+    public int getBondingStyle(GBDeviceCandidate deviceCandidate){
+        return BONDING_STYLE_NONE;
+    }
+
+    @Override
     public DeviceType getDeviceType() {
         return DeviceType.HPLUS;
     }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusCoordinator.java
@@ -81,7 +81,7 @@ public class HPlusCoordinator extends AbstractDeviceCoordinator {
     }
 
     @Override
-    public int getBondingStyle(GBDeviceCandidate deviceCandidate){
+    public int getBondingStyle(GBDevice deviceCandidate){
         return BONDING_STYLE_NONE;
     }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/BluetoothPairingRequestReceiver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/BluetoothPairingRequestReceiver.java
@@ -1,0 +1,73 @@
+/*  Copyright (C) 2015-2017 João Paulo Barraca
+
+    This file is part of Gadgetbridge.
+
+    Gadgetbridge is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Gadgetbridge is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+package nodomain.freeyourgadget.gadgetbridge.externalevents;
+
+import android.bluetooth.BluetoothDevice;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import nodomain.freeyourgadget.gadgetbridge.devices.DeviceCoordinator;
+import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
+import nodomain.freeyourgadget.gadgetbridge.impl.GBDeviceCandidate;
+import nodomain.freeyourgadget.gadgetbridge.service.DeviceCommunicationService;
+import nodomain.freeyourgadget.gadgetbridge.util.DeviceHelper;
+
+/**
+ * Created by jpbarraca on 13/04/2017.
+ */
+
+public class BluetoothPairingRequestReceiver extends BroadcastReceiver {
+
+
+    private static final Logger LOG = LoggerFactory.getLogger(BluetoothConnectReceiver.class);
+
+    final DeviceCommunicationService service;
+
+    public BluetoothPairingRequestReceiver(DeviceCommunicationService service) {
+        this.service = service;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+
+
+        if (!action.equals(BluetoothDevice.ACTION_PAIRING_REQUEST)) {
+            return;
+        }
+
+        GBDevice gbDevice = service.getGBDevice();
+        BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+        if (gbDevice == null || device == null)
+            return;
+
+        DeviceCoordinator coordinator = DeviceHelper.getInstance().getCoordinator(gbDevice);
+        GBDeviceCandidate candidate = new GBDeviceCandidate(device, gbDevice.getRssi(), device.getUuids());
+        try {
+            if (coordinator.getBondingStyle(candidate) == DeviceCoordinator.BONDING_STYLE_NONE) {
+                LOG.info("Aborting unwanted pairing request");
+                abortBroadcast();
+            }
+        } catch (Exception e) {
+
+        }
+    }
+}

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/BluetoothPairingRequestReceiver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/BluetoothPairingRequestReceiver.java
@@ -60,13 +60,13 @@ public class BluetoothPairingRequestReceiver extends BroadcastReceiver {
             return;
 
         DeviceCoordinator coordinator = DeviceHelper.getInstance().getCoordinator(gbDevice);
-        GBDeviceCandidate candidate = new GBDeviceCandidate(device, gbDevice.getRssi(), device.getUuids());
         try {
-            if (coordinator.getBondingStyle(candidate) == DeviceCoordinator.BONDING_STYLE_NONE) {
+            if (coordinator.getBondingStyle(gbDevice) == DeviceCoordinator.BONDING_STYLE_NONE) {
                 LOG.info("Aborting unwanted pairing request");
                 abortBroadcast();
             }
         } catch (Exception e) {
+            LOG.warn("Could not abort pairing request process");
 
         }
     }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
@@ -44,6 +44,7 @@ import nodomain.freeyourgadget.gadgetbridge.R;
 import nodomain.freeyourgadget.gadgetbridge.externalevents.AlarmClockReceiver;
 import nodomain.freeyourgadget.gadgetbridge.externalevents.AlarmReceiver;
 import nodomain.freeyourgadget.gadgetbridge.externalevents.BluetoothConnectReceiver;
+import nodomain.freeyourgadget.gadgetbridge.externalevents.BluetoothPairingRequestReceiver;
 import nodomain.freeyourgadget.gadgetbridge.externalevents.MusicPlaybackReceiver;
 import nodomain.freeyourgadget.gadgetbridge.externalevents.PebbleReceiver;
 import nodomain.freeyourgadget.gadgetbridge.externalevents.PhoneCallReceiver;
@@ -164,6 +165,7 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
     private MusicPlaybackReceiver mMusicPlaybackReceiver = null;
     private TimeChangeReceiver mTimeChangeReceiver = null;
     private BluetoothConnectReceiver mBlueToothConnectReceiver = null;
+    private BluetoothPairingRequestReceiver mBlueToothPairingRequestReceiver = null;
     private AlarmClockReceiver mAlarmClockReceiver = null;
 
     private AlarmReceiver mAlarmReceiver = null;
@@ -609,6 +611,11 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 mBlueToothConnectReceiver = new BluetoothConnectReceiver(this);
                 registerReceiver(mBlueToothConnectReceiver, new IntentFilter(BluetoothDevice.ACTION_ACL_CONNECTED));
             }
+            if (mBlueToothPairingRequestReceiver == null) {
+                mBlueToothPairingRequestReceiver = new BluetoothPairingRequestReceiver(this);
+                registerReceiver(mBlueToothPairingRequestReceiver, new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST));
+            }
+
             if (mAlarmReceiver == null) {
                 mAlarmReceiver = new AlarmReceiver();
                 registerReceiver(mAlarmReceiver, new IntentFilter("DAILY_ALARM"));
@@ -645,6 +652,12 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 unregisterReceiver(mBlueToothConnectReceiver);
                 mBlueToothConnectReceiver = null;
             }
+
+            if (mBlueToothPairingRequestReceiver != null) {
+                unregisterReceiver(mBlueToothPairingRequestReceiver);
+                mBlueToothPairingRequestReceiver = null;
+            }
+
             if (mAlarmReceiver != null) {
                 unregisterReceiver(mAlarmReceiver);
                 mAlarmReceiver = null;

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/btle/BleNamesResolver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/btle/BleNamesResolver.java
@@ -101,6 +101,7 @@ public class BleNamesResolver {
 		mServices.put("00001804-0000-1000-8000-00805f9b34fb", "Tx Power");
 		mServices.put("0000fee0-0000-3512-2118-0009af100700", "(Propr: Xiaomi MiLi Service)");
 		mServices.put("00001530-0000-3512-2118-0009af100700", "(Propr: Xiaomi Weight Service)");
+		mServices.put("14701820-620a-3973-7c78-9cfff0876abd", "(Propr: HPLUS Service)");
 
 		
 		mCharacteristics.put("00002a43-0000-1000-8000-00805f9b34fb", "Alert AlertCategory ID");
@@ -185,6 +186,8 @@ public class BleNamesResolver {
 		mCharacteristics.put("00002a07-0000-1000-8000-00805f9b34fb", "Tx Power Level");
 		mCharacteristics.put("00002a45-0000-1000-8000-00805f9b34fb", "Unread Alert Status");
 		
+		mCharacteristics.put("14702856-620a-3973-7c78-9cfff0876abd", "(Propr: HPLUS Control)");
+		mCharacteristics.put("14702853-620a-3973-7c78-9cfff0876abd", "(Propr: HPLUS Measurements)");
 		mValueFormats.put(Integer.valueOf(52), "32bit float");
 		mValueFormats.put(Integer.valueOf(50), "16bit float");
 		mValueFormats.put(Integer.valueOf(34), "16bit signed int");

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusDataRecordDaySlot.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusDataRecordDaySlot.java
@@ -102,4 +102,8 @@ public class HPlusDataRecordDaySlot extends HPlusDataRecord {
 
         secondsInactive += other.secondsInactive;
     }
+
+    public boolean isValid(){
+        return steps != 0 || secondsInactive != 0 || heartRate != -1;
+    }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -94,8 +94,6 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
 
         deviceType = type;
 
-        addSupportedService(GattService.UUID_SERVICE_GENERIC_ACCESS);
-        addSupportedService(GattService.UUID_SERVICE_GENERIC_ATTRIBUTE);
         addSupportedService(HPlusConstants.UUID_SERVICE_HP);
 
         LocalBroadcastManager broadcastManager = LocalBroadcastManager.getInstance(getContext());


### PR DESCRIPTION
Improve the connection process with HPlus devices and fixes #642 
Assumed that HPlus devices do not require pairing as they will reset to factory defaults when pairing.
Created method to block the pairing request if no bond is required by the coordinator.
Added periodic keep alive packets. 
This will be controlled by an option in a near future.

