### PR TITLE
Support control of multiple media playback applications

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBMusicControlReceiver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBMusicControlReceiver.java
@@ -18,17 +18,24 @@
 package nodomain.freeyourgadget.gadgetbridge.service.receivers;
 
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
+import android.media.session.MediaController;
+import android.media.session.MediaSessionManager;
 import android.os.SystemClock;
+import android.util.Log;
 import android.view.KeyEvent;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventMusicControl;
+import nodomain.freeyourgadget.gadgetbridge.externalevents.NotificationListener;
 import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
 
 public class GBMusicControlReceiver extends BroadcastReceiver {
@@ -72,6 +79,23 @@ public class GBMusicControlReceiver extends BroadcastReceiver {
         if (keyCode != -1) {
             Prefs prefs = GBApplication.getPrefs();
             String audioPlayer = prefs.getString("audio_player", "default");
+
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                MediaSessionManager mediaSessionManager =
+                        (MediaSessionManager) context.getSystemService(Context.MEDIA_SESSION_SERVICE);
+
+                List<MediaController> controllers = mediaSessionManager.getActiveSessions(
+                        new ComponentName(context, NotificationListener.class));
+                try {
+                    MediaController controller = controllers.get(0);
+                    audioPlayer = controller.getPackageName();
+                } catch (IndexOutOfBoundsException e) {
+                    System.err.println("IndexOutOfBoundsException: " + e.getMessage());
+                }
+            }
+
+            Log.d("keypress", musicCmd.toString());
+            Log.d("sent to", audioPlayer);
 
             long eventtime = SystemClock.uptimeMillis();
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBMusicControlReceiver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBMusicControlReceiver.java
@@ -25,7 +25,6 @@ import android.media.AudioManager;
 import android.media.session.MediaController;
 import android.media.session.MediaSessionManager;
 import android.os.SystemClock;
-import android.util.Log;
 import android.view.KeyEvent;
 
 import org.slf4j.Logger;
@@ -94,8 +93,7 @@ public class GBMusicControlReceiver extends BroadcastReceiver {
                 }
             }
 
-            Log.d("keypress", musicCmd.toString());
-            Log.d("sent to", audioPlayer);
+            LOG.debug("keypress: " + musicCmd.toString() + " sent to: " + audioPlayer);
 
             long eventtime = SystemClock.uptimeMillis();
 


### PR DESCRIPTION
Using the MediaSessionManager we can detect current playback sessions and getPackageName allowing playback control intents to be directed at the application currently playing media/last seen playing media.

This API feature is LOLLIPOP or greater only, however KITKAT functionality has been left unchanged.
On 5+ the ```Preferred Audioplayer``` preference will only be used if no playback sessions are detected.

Fixes [639](https://github.com/Freeyourgadget/Gadgetbridge/issues/639)

