### PR TITLE
Mi Band 2: Find lost device while in DND

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband2/MiBand2Support.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband2/MiBand2Support.java
@@ -664,17 +664,15 @@ public class MiBand2Support extends AbstractBTLEDeviceSupport {
 
     @Override
     public void onFindDevice(boolean start) {
-        isLocatingDevice = start;
-
         if (start) {
-            AbortTransactionAction abortAction = new AbortTransactionAction() {
-                @Override
-                protected boolean shouldAbort() {
-                    return !isLocatingDevice;
-                }
-            };
-            SimpleNotification simpleNotification = new SimpleNotification(getContext().getString(R.string.find_device_you_found_it), AlertCategory.HighPriorityAlert);
-            performDefaultNotification("locating device", simpleNotification, (short) 255, abortAction);
+            try {
+                TransactionBuilder builder = performInitialized("Mi Band 2 - Find Device");
+                // ALERT_LEVEL_VIBRATE_ONLY ensures band vibrates, even while in DND
+                builder.write(getCharacteristic(GattCharacteristic.UUID_CHARACTERISTIC_ALERT_LEVEL), new byte[]{MiBand2Service.ALERT_LEVEL_VIBRATE_ONLY});
+                performConnected(builder.getTransaction());
+            } catch (IOException e) {
+                LOG.error("Error finding Mi Band 2: ", e);
+            }
         }
     }
 


### PR DESCRIPTION
This fixes #752 

While in Do Not Disturb, the Mi Band 2 doesn't vibrate for notifications / calls. If we set the alert level to vibrate only it will vibrate while in DND.

If the Amazfit Bip has the same problem we might be able to fix it in the same way.