### PR TITLE
Add support for ukrainian characters

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
@@ -59,6 +59,9 @@ public class LanguageUtils {
             put('Ξ',"KS");put('Ο',"O");put('Ό',"O");put('Π',"P");put('Ρ',"R");put('Σ',"S");put('Τ',"T");put('Υ',"Y");put('Ύ',"Y");
             put('Ϋ',"Y");put('Φ',"F");put('Χ',"CH");put('Ψ',"PS");put('Ω',"O");put('Ώ',"O");
 
+            //ukrainian characters
+            put('ґ', "gh"); put('є', "je"); put('і', "i"); put('ї', "ji"); put('Ґ', "GH"); put('Є', "JE"); put('І', "I"); put('Ї', "JI");
+            
             //TODO: these must be configurabe. If someone wants to transliterate cyrillic it does not mean his device has no German umlauts
             //all or nothing is really bad here
         }


### PR DESCRIPTION
- 'ґ' (Cyrillic Small Letter Ghe with Upturn U+0491) / 'Ґ' (Cyrillic Capital Letter Ghe with Upturn U+0490);
- 'є' (Cyrillic Small Letter Ukrainian Ie U+0454) / 'Є' (Cyrillic Capital Letter Ukrainian Ie U+0404);
- 'і' (Cyrillic Small Letter Byelorussian-Ukrainian I U+0456) / 'І' (Cyrillic Capital Letter Byelorussian-Ukrainian I U+0406);
- 'ї' (Cyrillic Small Letter Yi U+0457) / 'Ї' (Cyrillic Capital Letter Yi U+0407)