### PR TITLE
Allow WeChat notifications

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -394,7 +394,7 @@ public class NotificationListener extends NotificationListenerService {
         }
 
         return shouldIgnoreSource(sbn.getPackageName()) || shouldIgnoreNotification(
-                sbn.getNotification());
+                sbn.getNotification(), sbn.getPackageName());
 
     }
 
@@ -432,15 +432,18 @@ public class NotificationListener extends NotificationListenerService {
         return false;
     }
 
-    private boolean shouldIgnoreNotification(Notification notification) {
+    private boolean shouldIgnoreNotification(Notification notification, String source) {
 
         MediaSessionCompat.Token mediaSession = NotificationCompat.getMediaSession(notification);
         //try to handle media session notifications
         if (mediaSession != null && handleMediaSessionNotification(mediaSession))
             return true;
 
+        NotificationType type = AppNotificationType.getInstance().get(source);
         //ignore notifications marked as LocalOnly https://developer.android.com/reference/android/app/Notification.html#FLAG_LOCAL_ONLY
-        if (NotificationCompat.getLocalOnly(notification))
+        if (NotificationCompat.getLocalOnly(notification) &&
+                //WeChat always marks its notifications as LocalOnly, do not ignore them
+                type != NotificationType.WECHAT)
             return true;
 
         Prefs prefs = GBApplication.getPrefs();


### PR DESCRIPTION
It seems WeChat always mark its notifications as LocalOnly. The reason
may be to avoid double notifications when using Android Wear watches,
since WeChat has a standalone Android Wear app.

Do not ignore WeChat notifications even if they're marked as LocalOnly.