### PR TITLE
Mi Band 2: whitelist firmware 1.0.1.54

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband2/Mi2FirmwareInfo.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband2/Mi2FirmwareInfo.java
@@ -55,6 +55,7 @@ public class Mi2FirmwareInfo extends HuamiFirmwareInfo {
         crcToVersion.put(32450, "1.0.1.28");
         crcToVersion.put(51770, "1.0.1.34");
         crcToVersion.put(3929, "1.0.1.39");
+        crcToVersion.put(47364 , "1.0.1.54");
 
         // fonts
         crcToVersion.put(45624, "Font");


### PR DESCRIPTION
Firmware version 1.0.1.54 is marked as recommended on wiki (Mi Band
Firmware Information).
And it also seems to be working fine on my device. :)