### PR TITLE
Combine multipart SMS message into messages by sender

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/SMSReceiver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/SMSReceiver.java
@@ -26,6 +26,9 @@ import android.os.Bundle;
 import android.os.PowerManager;
 import android.telephony.SmsMessage;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.NotificationType;
@@ -54,12 +57,22 @@ public class SMSReceiver extends BroadcastReceiver {
         if (bundle != null) {
             Object[] pdus = (Object[]) bundle.get("pdus");
             if (pdus != null) {
-                for (Object pdu1 : pdus) {
-                    byte[] pdu = (byte[]) pdu1;
-                    SmsMessage message = SmsMessage.createFromPdu(pdu);
-                    notificationSpec.body = message.getDisplayMessageBody();
-                    notificationSpec.phoneNumber = message.getOriginatingAddress();
-                    if (notificationSpec.phoneNumber != null) {
+                int pduSize = pdus.length;
+                Map<String, StringBuilder> messageMap = new LinkedHashMap<>();
+                SmsMessage[] messages = new SmsMessage[pduSize];
+                for (int i = 0; i < pduSize; i++) {
+                    messages[i] = SmsMessage.createFromPdu((byte[]) pdus[i]);
+                    String originatingAddress = messages[i].getOriginatingAddress();
+                    if (!messageMap.containsKey(originatingAddress)) {
+                        messageMap.put(originatingAddress, new StringBuilder());
+                    }
+                    messageMap.get(originatingAddress).append(messages[i].getMessageBody());
+                }
+                for (Map.Entry<String, StringBuilder> entry : messageMap.entrySet()) {
+                    String originatingAddress = entry.getKey();
+                    if (originatingAddress != null) {
+                        notificationSpec.body = entry.getValue().toString();
+                        notificationSpec.phoneNumber = originatingAddress;
                         switch (GBApplication.getGrantedInterruptionFilter()) {
                             case NotificationManager.INTERRUPTION_FILTER_ALL:
                                 break;


### PR DESCRIPTION
When receive SMS message, instead of generating multiple notifications by
PDU size, after this change, there will be only one notification for
each sender.