### PR TITLE
[RFC] Mi Band 2: Add rudimentary raw sensor data support

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBand2Service.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBand2Service.java
@@ -35,8 +35,8 @@ public class MiBand2Service {
     public static final UUID UUID_CHARACTERISTIC_FIRMWARE_DATA = UUID.fromString("00001532-0000-3512-2118-0009af100700");
 
     public static final UUID UUID_UNKNOWN_CHARACTERISTIC0 = UUID.fromString("00000000-0000-3512-2118-0009af100700");
-    public static final UUID UUID_UNKNOWN_CHARACTERISTIC1 = UUID.fromString("00000001-0000-3512-2118-0009af100700");
-    public static final UUID UUID_UNKNOWN_CHARACTERISTIC2 = UUID.fromString("00000002-0000-3512-2118-0009af100700");
+    public static final UUID UUID_CHARACTERISTIC_1_SENSOR_CONTROL = UUID.fromString("00000001-0000-3512-2118-0009af100700");
+    public static final UUID UUID_CHARACTERISTIC_2_SENSOR_DATA = UUID.fromString("00000002-0000-3512-2118-0009af100700");
     /**
      * Alarms, Display and other configuration.
      */

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband2/MiBand2Support.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband2/MiBand2Support.java
@@ -154,11 +154,16 @@ public class MiBand2Support extends AbstractBTLEDeviceSupport {
     private boolean needsAuth;
     private volatile boolean telephoneRinging;
     private volatile boolean isLocatingDevice;
+    private volatile boolean isReadingSensorData;
 
     private final GBDeviceEventVersionInfo versionCmd = new GBDeviceEventVersionInfo();
     private final GBDeviceEventBatteryInfo batteryCmd = new GBDeviceEventBatteryInfo();
     private RealtimeSamplesSupport realtimeSamplesSupport;
     private boolean alarmClockRinging;
+
+    private static final byte[] startSensorRead1 = new byte[]{0x01, 0x01, 0x19};
+    private static final byte[] startSensorRead2 = new byte[]{0x02};
+    private static final byte[] stopSensorRead = new byte[]{0x03};
 
     public MiBand2Support() {
         this(LOG);
@@ -271,6 +276,7 @@ public class MiBand2Support extends AbstractBTLEDeviceSupport {
         builder.notify(getCharacteristic(MiBand2Service.UUID_CHARACTERISTIC_3_CONFIGURATION), enable);
         builder.notify(getCharacteristic(MiBand2Service.UUID_CHARACTERISTIC_6_BATTERY_INFO), enable);
         builder.notify(getCharacteristic(MiBand2Service.UUID_CHARACTERISTIC_DEVICEEVENT), enable);
+        builder.notify(getCharacteristic(MiBand2Service.UUID_CHARACTERISTIC_2_SENSOR_DATA), enable);
 
         return this;
     }
@@ -1037,6 +1043,9 @@ public class MiBand2Support extends AbstractBTLEDeviceSupport {
         } else if (MiBand2Service.UUID_CHARACTERISTIC_7_REALTIME_STEPS.equals(characteristicUUID)) {
             handleRealtimeSteps(characteristic.getValue());
             return true;
+        } else if (MiBand2Service.UUID_CHARACTERISTIC_2_SENSOR_DATA.equals(characteristicUUID)) {
+            handleSensorData(characteristic.getValue());
+            return true;
         } else {
             LOG.info("Unhandled characteristic changed: " + characteristicUUID);
             logMessageContent(characteristic.getValue());
@@ -1129,6 +1138,10 @@ public class MiBand2Support extends AbstractBTLEDeviceSupport {
         } else {
             LOG.warn("Unrecognized realtime steps value: " + Logging.formatBytes(value));
         }
+    }
+
+    private void handleSensorData(byte[] value) {
+        // See logcat for raw data output
     }
 
     private void enableRealtimeSamplesTimer(boolean enable) {
@@ -1350,9 +1363,16 @@ public class MiBand2Support extends AbstractBTLEDeviceSupport {
     public void onTestNewFunction() {
         try {
             TransactionBuilder builder = performInitialized("test realtime steps");
-            builder.read(getCharacteristic(MiBand2Service.UUID_CHARACTERISTIC_7_REALTIME_STEPS));
+            if (isReadingSensorData) {
+                builder.write(getCharacteristic(MiBand2Service.UUID_CHARACTERISTIC_1_SENSOR_CONTROL), stopSensorRead);
+            } else {
+                builder.write(getCharacteristic(MiBand2Service.UUID_CHARACTERISTIC_1_SENSOR_CONTROL), startSensorRead1);
+                builder.write(getCharacteristic(MiBand2Service.UUID_CHARACTERISTIC_1_SENSOR_CONTROL), startSensorRead2);
+            }
             builder.queue(getQueue());
+            isReadingSensorData = !isReadingSensorData;
         } catch (IOException e) {
+            LOG.error("Unable to toggle sensor reading MI2", e);
         }
     }
 


### PR DESCRIPTION
I have been playing with a third party application whose name seems better not to mention. After replaying some of the writes it does when cooperating with Sleep as Android I got something which looks very much like raw sensor data.

A logcat dump is available on https://p.atx.name/uhuhozuvoy . The bytes look easy to convert at first glance (maybe even the same as the Mi Band 1?), but I have ran out of time for today.

This is not really useful at the moment, but eventually it would be nice to add [integration](https://sleep.urbandroid.org/documentation/developer-api/) with Sleep as Android (or an OSS alternative, if there is any) (thus bypassing the need for having Mi Fit + the aforementioned third party app installed).

I am mostly putting this PR here as a request for comments/patches, so if anyone has more empty timeslots than me...