### PR TITLE
Added Etar as calendar app type

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
@@ -138,6 +138,9 @@ public class AppNotificationType extends HashMap<String, NotificationType> {
 
         // Transit
         put("com.thetransitapp.droid", NotificationType.TRANSIT);
+
+        // Etar
+        put("ws.xsoh.etar", NotificationType.GENERIC_CALENDAR);
     }
 
 }


### PR DESCRIPTION
Etar is a FOSS calendar app distributed on [F-Droid](https://f-droid.org/packages/ws.xsoh.etar/). I have not tested this change since I don't have the SDK set up.