### PR TITLE
add Facebook Messenger Lite notification support

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
@@ -84,6 +84,7 @@ public class AppNotificationType extends HashMap<String, NotificationType> {
 
         // Facebook Messenger
         put("com.facebook.orca", NotificationType.FACEBOOK_MESSENGER);
+        put("com.facebook.mlite", NotificationType.FACEBOOK_MESSENGER);
 
         // WhatsApp
         put("com.whatsapp", NotificationType.WHATSAPP);


### PR DESCRIPTION
As discussed in #883, this PR lets Gadgetbridge detect notifications coming from Facebook Messenger Lite as `NotificationType.FACEBOOK_MESSENGER`.