### PR TITLE
First try at periodic db export

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -345,6 +345,12 @@
                 <action android:name="nodomain.freeyourgadget.gadgetbridge.callcontrol" />
             </intent-filter>
         </receiver>
+        <receiver
+            android:enabled="true"
+            android:name="nodomain.freeyourgadget.gadgetbridge.database.PeriodicExporter"
+            android:exported="false">
+
+        </receiver>
 
         <!--
             forcing the DebugActivity to portrait mode avoids crashes with the progress

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
@@ -59,6 +59,7 @@ import nodomain.freeyourgadget.gadgetbridge.database.PeriodicExporter;
 import nodomain.freeyourgadget.gadgetbridge.devices.DeviceManager;
 import nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandPreferencesActivity;
 import nodomain.freeyourgadget.gadgetbridge.model.CannedMessagesSpec;
+import nodomain.freeyourgadget.gadgetbridge.util.AndroidUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.FileUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.GBPrefs;
@@ -385,7 +386,7 @@ public class SettingsActivity extends AbstractSettingsActivity {
         }
         Uri uri = Uri.parse(autoExportLocation);
         try {
-            String filePath = getFilePath(getApplicationContext(), uri);
+            String filePath = AndroidUtils.getFilePath(getApplicationContext(), uri);
             if (filePath != null) {
                 return filePath;
             }
@@ -402,61 +403,6 @@ public class SettingsActivity extends AbstractSettingsActivity {
         }
         return "";
     }
-
-    /*
-    As seen on stackoverflow https://stackoverflow.com/a/36714242/1207186
-    Try to find the file path of a document uri
-     */
-    private String getFilePath(Context context, Uri uri) throws URISyntaxException {
-        String selection = null;
-        String[] selectionArgs = null;
-        // Uri is different in versions after KITKAT (Android 4.4), we need to
-        if (Build.VERSION.SDK_INT >= 19 && DocumentsContract.isDocumentUri(context.getApplicationContext(), uri)) {
-            if ("com.android.externalstorage.documents".equals(uri.getAuthority())) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                return Environment.getExternalStorageDirectory() + "/" + split[1];
-            } else if ("com.android.providers.downloads.documents".equals(uri.getAuthority())) {
-                final String id = DocumentsContract.getDocumentId(uri);
-                uri = ContentUris.withAppendedId(
-                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-            } else if ("com.android.providers.media.documents".equals(uri.getAuthority())) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
-                if ("image".equals(type)) {
-                    uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-                } else if ("video".equals(type)) {
-                    uri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-                } else if ("audio".equals(type)) {
-                    uri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-                }
-                selection = "_id=?";
-                selectionArgs = new String[]{
-                        split[1]
-                };
-            }
-        }
-        if ("content".equalsIgnoreCase(uri.getScheme())) {
-            String[] projection = {
-                    MediaStore.Images.Media.DATA
-            };
-            Cursor cursor = null;
-            try {
-                cursor = context.getContentResolver()
-                        .query(uri, projection, selection, selectionArgs, null);
-                int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
-                if (cursor.moveToFirst()) {
-                    return cursor.getString(column_index);
-                }
-            } catch (Exception e) {
-            }
-        } else if ("file".equalsIgnoreCase(uri.getScheme())) {
-            return uri.getPath();
-        }
-        return null;
-    }
-
 
     /*
      * delayed execution so that the preferences are applied first

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
@@ -293,6 +293,7 @@ public class SettingsActivity extends AbstractSettingsActivity {
                 Intent i = new Intent(Intent.ACTION_CREATE_DOCUMENT);
                 i.setType("application/x-sqlite3");
                 i.addCategory(Intent.CATEGORY_OPENABLE);
+                i.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
                 String title = getApplicationContext().getString(R.string.choose_auto_export_location);
                 startActivityForResult(Intent.createChooser(i, title), FILE_REQUEST_CODE);
                 return true;
@@ -355,9 +356,10 @@ public class SettingsActivity extends AbstractSettingsActivity {
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == FILE_REQUEST_CODE && data != null) {
-            Uri uri = data.getData();
+    protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        if (requestCode == FILE_REQUEST_CODE && intent != null) {
+            Uri uri = intent.getData();
+            getContentResolver().takePersistableUriPermission(uri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
             PreferenceManager
                     .getDefaultSharedPreferences(this)
                     .edit()

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
@@ -57,6 +57,7 @@ import nodomain.freeyourgadget.gadgetbridge.devices.miband.MiBandPreferencesActi
 import nodomain.freeyourgadget.gadgetbridge.model.CannedMessagesSpec;
 import nodomain.freeyourgadget.gadgetbridge.util.FileUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
+import nodomain.freeyourgadget.gadgetbridge.util.GBPrefs;
 import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
 
 import static nodomain.freeyourgadget.gadgetbridge.model.ActivityUser.PREF_USER_HEIGHT_CM;
@@ -351,15 +352,14 @@ public class SettingsActivity extends AbstractSettingsActivity {
 
             Cursor cursor = getContentResolver().query(
                     uri,
-                    new String[] { DocumentsContract.Document.COLUMN_DISPLAY_NAME, DocumentsContract.Document.COLUMN_SUMMARY },
+                    new String[] { DocumentsContract.Document.COLUMN_DISPLAY_NAME },
                     null, null, null, null
             );
             if (cursor == null || ! cursor.moveToFirst()) {
+                LOG.warn("Unable to fetch information on URI " + uri.toString());
                 return;
             }
             String displayName = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
-            String summary = cursor.getString(cursor.getColumnIndex(DocumentsContract.Document.COLUMN_SUMMARY));
-            LOG.info(displayName + " " + summary);
             findPreference("export_location").setSummary(displayName);
             boolean autoExportEnabled = GBApplication
                     .getPrefs().getBoolean("auto_export_enabled", false);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/DBHelper.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/DBHelper.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -113,6 +115,16 @@ public class DBHelper {
 
             FileUtils.copyFile(sourceFile, destFile);
             return destFile;
+        } finally {
+            dbHandler.openDb();
+        }
+    }
+
+    public void exportDB(DBHandler dbHandler, OutputStream dest) throws IOException {
+        String dbPath = getClosedDBPath(dbHandler);
+        try {
+            File source = new File(dbPath);
+            FileUtils.copyFileToStream(source, dest);
         } finally {
             dbHandler.openDb();
         }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/PeriodicExporter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/PeriodicExporter.java
@@ -16,6 +16,7 @@ import java.io.OutputStream;
 import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.R;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
+import nodomain.freeyourgadget.gadgetbridge.util.GBPrefs;
 
 /**
  * Created by maufl on 1/4/18.
@@ -51,7 +52,7 @@ public class PeriodicExporter extends BroadcastReceiver {
         LOG.info("Exporting DB");
         try (DBHandler dbHandler = GBApplication.acquireDB()) {
             DBHelper helper = new DBHelper(context);
-            String dst = GBApplication.getPrefs().getString("export_location", null);
+            String dst = GBApplication.getPrefs().getString(GBPrefs.AUTO_EXPORT_LOCATION, null);
             if (dst == null) {
                 LOG.info("Unable to export DB, export location not set");
                 return;

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/PeriodicExporter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/PeriodicExporter.java
@@ -14,6 +14,8 @@ import org.slf4j.LoggerFactory;
 import java.io.OutputStream;
 
 import nodomain.freeyourgadget.gadgetbridge.GBApplication;
+import nodomain.freeyourgadget.gadgetbridge.R;
+import nodomain.freeyourgadget.gadgetbridge.util.GB;
 
 /**
  * Created by maufl on 1/4/18.
@@ -31,7 +33,7 @@ public class PeriodicExporter extends BroadcastReceiver {
         if (!autoExportEnabled) {
             return;
         }
-        int exportPeriod = autoExportPeriod * 1000;// * 60 * 60 * 1000;
+        int exportPeriod = autoExportPeriod * 60 * 60 * 1000;
         if (exportPeriod == 0) {
             return;
         }
@@ -51,13 +53,14 @@ public class PeriodicExporter extends BroadcastReceiver {
             DBHelper helper = new DBHelper(context);
             String dst = GBApplication.getPrefs().getString("export_location", null);
             if (dst == null) {
-                LOG.info("Unable to export DB, export locatio not set");
+                LOG.info("Unable to export DB, export location not set");
                 return;
             }
             Uri dstUri = Uri.parse(dst);
             OutputStream out = context.getContentResolver().openOutputStream(dstUri);
             helper.exportDB(dbHandler, out);
         } catch (Exception ex) {
+            GB.updateExportFailedNotification(context.getString(R.string.notif_export_failed_title), context);
             LOG.info("Exception while exporting DB: ", ex);
         }
     }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/PeriodicExporter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/PeriodicExporter.java
@@ -1,0 +1,64 @@
+package nodomain.freeyourgadget.gadgetbridge.database;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.SystemClock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.OutputStream;
+
+import nodomain.freeyourgadget.gadgetbridge.GBApplication;
+
+/**
+ * Created by maufl on 1/4/18.
+ */
+
+public class PeriodicExporter extends BroadcastReceiver {
+    private static final Logger LOG = LoggerFactory.getLogger(PeriodicExporter.class);
+
+
+    public static void sheduleAlarm(Context context, Integer autoExportPeriod, boolean autoExportEnabled) {
+        Intent i = new Intent(context, PeriodicExporter.class);
+        PendingIntent pi = PendingIntent.getBroadcast(context, 0 , i, 0);
+        AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        am.cancel(pi);
+        if (!autoExportEnabled) {
+            return;
+        }
+        int exportPeriod = autoExportPeriod * 1000;// * 60 * 60 * 1000;
+        if (exportPeriod == 0) {
+            return;
+        }
+        LOG.info("Enabling periodic export");
+        am.setInexactRepeating(
+                AlarmManager.ELAPSED_REALTIME,
+                SystemClock.elapsedRealtime() + exportPeriod,
+                exportPeriod,
+                pi
+        );
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        LOG.info("Exporting DB");
+        try (DBHandler dbHandler = GBApplication.acquireDB()) {
+            DBHelper helper = new DBHelper(context);
+            String dst = GBApplication.getPrefs().getString("export_location", null);
+            if (dst == null) {
+                LOG.info("Unable to export DB, export locatio not set");
+                return;
+            }
+            Uri dstUri = Uri.parse(dst);
+            OutputStream out = context.getContentResolver().openOutputStream(dstUri);
+            helper.exportDB(dbHandler, out);
+        } catch (Exception ex) {
+            LOG.info("Exception while exporting DB: ", ex);
+        }
+    }
+}

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/PeriodicExporter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/database/PeriodicExporter.java
@@ -17,6 +17,7 @@ import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.R;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.GBPrefs;
+import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
 
 /**
  * Created by maufl on 1/4/18.
@@ -25,8 +26,14 @@ import nodomain.freeyourgadget.gadgetbridge.util.GBPrefs;
 public class PeriodicExporter extends BroadcastReceiver {
     private static final Logger LOG = LoggerFactory.getLogger(PeriodicExporter.class);
 
+    public static void enablePeriodicExport(Context context) {
+        Prefs prefs = GBApplication.getPrefs();
+        boolean autoExportEnabled = prefs.getBoolean(GBPrefs.AUTO_EXPORT_ENABLED, false);
+        Integer autoExportInterval = prefs.getInt(GBPrefs.AUTO_EXPORT_INTERVAL, 0);
+        sheduleAlarm(context, autoExportInterval, autoExportEnabled);
+    }
 
-    public static void sheduleAlarm(Context context, Integer autoExportPeriod, boolean autoExportEnabled) {
+    public static void sheduleAlarm(Context context, Integer autoExportInterval, boolean autoExportEnabled) {
         Intent i = new Intent(context, PeriodicExporter.class);
         PendingIntent pi = PendingIntent.getBroadcast(context, 0 , i, 0);
         AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
@@ -34,7 +41,7 @@ public class PeriodicExporter extends BroadcastReceiver {
         if (!autoExportEnabled) {
             return;
         }
-        int exportPeriod = autoExportPeriod * 60 * 60 * 1000;
+        int exportPeriod = autoExportInterval * 60 * 60 * 1000;
         if (exportPeriod == 0) {
             return;
         }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/AutoStartReceiver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/AutoStartReceiver.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.util.Log;
 
 import nodomain.freeyourgadget.gadgetbridge.GBApplication;
+import nodomain.freeyourgadget.gadgetbridge.database.PeriodicExporter;
 
 public class AutoStartReceiver extends BroadcastReceiver {
     private static final String TAG = AutoStartReceiver.class.getName();
@@ -31,6 +32,7 @@ public class AutoStartReceiver extends BroadcastReceiver {
         if (GBApplication.getGBPrefs().getAutoStart() && Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
             Log.i(TAG, "Boot completed, starting Gadgetbridge");
             GBApplication.deviceService().start();
+            PeriodicExporter.enablePeriodicExport(context);
         }
     }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/FileUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/FileUtils.java
@@ -133,7 +133,6 @@ public class FileUtils {
         try (OutputStream bufOut = new BufferedOutputStream(out)) {
             copyFileToStream(src, bufOut);
         }
-        out.close();
     }
 
     /**

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/FileUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/FileUtils.java
@@ -18,11 +18,13 @@ package nodomain.freeyourgadget.gadgetbridge.util;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.icu.util.Output;
 import android.net.Uri;
 import android.os.Environment;
 import android.support.annotation.NonNull;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -32,6 +34,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -82,6 +85,16 @@ public class FileUtils {
         }
     }
 
+    public static void copyFileToStream(File src, OutputStream dst) throws IOException {
+        try (FileInputStream in = new FileInputStream(src)) {
+            byte[] buf = new byte[4096];
+            while(in.available() > 0) {
+                int bytes = in.read(buf);
+                dst.write(buf, 0, bytes);
+            }
+        }
+    }
+
     public static void copyURItoFile(Context ctx, Uri uri, File destFile) throws IOException {
         if (uri.getPath().equals(destFile.getPath())) {
             return;
@@ -95,6 +108,17 @@ public class FileUtils {
         try (InputStream fin = new BufferedInputStream(in)) {
             copyStreamToFile(fin, destFile);
             fin.close();
+        }
+    }
+
+    public static void copyFileToURI(Context context, File src, Uri dst) throws IOException {
+        OutputStream out = context.getContentResolver().openOutputStream(dst);
+        if (out == null) {
+            throw new IOException("Unable to open output stream for " + dst.toString());
+        }
+        try (OutputStream bufOut = new BufferedOutputStream(out)) {
+            copyFileToStream(src, bufOut);
+            bufOut.close();
         }
     }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/FileUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/FileUtils.java
@@ -85,6 +85,12 @@ public class FileUtils {
         }
     }
 
+    /**
+     * Copies the contents of the given file to the destination output stream.
+     * @param src the file from which to read.
+     * @param dst the output stream that is written to. Note: the caller has to close the output stream!
+     * @throws IOException
+     */
     public static void copyFileToStream(File src, OutputStream dst) throws IOException {
         try (FileInputStream in = new FileInputStream(src)) {
             byte[] buf = new byte[4096];
@@ -111,6 +117,14 @@ public class FileUtils {
         }
     }
 
+    /**
+     * Copies the content of a file to an uri,
+     * which for example was retrieved using the storage access framework.
+     * @param context the application context.
+     * @param src the file from which the content should be copied.
+     * @param dst the destination uri.
+     * @throws IOException
+     */
     public static void copyFileToURI(Context context, File src, Uri dst) throws IOException {
         OutputStream out = context.getContentResolver().openOutputStream(dst);
         if (out == null) {
@@ -118,8 +132,8 @@ public class FileUtils {
         }
         try (OutputStream bufOut = new BufferedOutputStream(out)) {
             copyFileToStream(src, bufOut);
-            bufOut.close();
         }
+        out.close();
     }
 
     /**

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GB.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GB.java
@@ -44,6 +44,7 @@ import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.GBEnvironment;
 import nodomain.freeyourgadget.gadgetbridge.R;
 import nodomain.freeyourgadget.gadgetbridge.activities.ControlCenterv2;
+import nodomain.freeyourgadget.gadgetbridge.activities.SettingsActivity;
 import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventScreenshot;
 import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
 import nodomain.freeyourgadget.gadgetbridge.model.DeviceService;
@@ -54,6 +55,7 @@ public class GB {
     public static final int NOTIFICATION_ID_INSTALL = 2;
     public static final int NOTIFICATION_ID_LOW_BATTERY = 3;
     public static final int NOTIFICATION_ID_TRANSFER = 4;
+    public static final int NOTIFICATION_ID_EXPORT_FAILED = 5;
 
     private static final Logger LOG = LoggerFactory.getLogger(GB.class);
     public static final int INFO = 1;
@@ -419,6 +421,37 @@ public class GB {
     public static void removeBatteryNotification(Context context) {
         removeNotification(NOTIFICATION_ID_LOW_BATTERY, context);
     }
+
+    public static Notification createExportFailedNotification(String text, Context context) {
+        Intent notificationIntent = new Intent(context, SettingsActivity.class);
+        notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0,
+                notificationIntent, 0);
+
+        NotificationCompat.Builder nb = new NotificationCompat.Builder(context)
+                .setContentTitle(context.getString(R.string.notif_export_failed_title))
+                .setContentText(text)
+                .setContentIntent(pendingIntent)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setPriority(Notification.PRIORITY_HIGH)
+                .setOngoing(false);
+
+        return nb.build();
+    }
+
+    public static void updateExportFailedNotification(String text, Context context) {
+        if (GBEnvironment.env().isLocalTest()) {
+            return;
+        }
+        Notification notification = createExportFailedNotification(text, context);
+        updateNotification(notification, NOTIFICATION_ID_EXPORT_FAILED, context);
+    }
+
+    public static void removeExportFailedNotification(Context context) {
+        removeNotification(NOTIFICATION_ID_EXPORT_FAILED, context);
+    }
+
 
     public static void assertThat(boolean condition, String errorMessage) {
         if (!condition) {

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GBPrefs.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GBPrefs.java
@@ -24,6 +24,9 @@ public class GBPrefs {
     public static final String CALENDAR_BLACKLIST = "calendar_blacklist";
     public static final String AUTO_RECONNECT = "general_autocreconnect";
     private static final String AUTO_START = "general_autostartonboot";
+    public static final String AUTO_EXPORT_ENABLED = "auto_export_enabled";
+    public static final String AUTO_EXPORT_LOCATION = "auto_export_location";
+    public static final String AUTO_EXPORT_INTERVAL = "auto_export_interval";
     private static final boolean AUTO_START_DEFAULT = true;
     public static boolean AUTO_RECONNECT_DEFAULT = true;
 

--- a/app/src/main/res/layout/activity_db_management.xml
+++ b/app/src/main/res/layout/activity_db_management.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:grid="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -9,8 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <android.support.v7.widget.GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:grid="http://schemas.android.com/apk/res-auto"
+        <android.support.v7.widget.GridLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/activity_vertical_margin"
@@ -29,8 +29,8 @@
             <Button
                 android:id="@+id/importDBButton"
                 android:text="Import DB"
-                grid:layout_gravity="center"
-                grid:layout_column="1" />
+                grid:layout_column="1"
+                grid:layout_gravity="center" />
 
 
             <TextView
@@ -49,6 +49,13 @@
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 grid:layout_columnSpan="2"
                 grid:layout_columnWeight="1" />
+
+            <Button
+                android:id="@+id/chooseDirectory"
+                android:text="Choose Directory"
+                grid:layout_columnSpan="2"
+                grid:layout_columnWeight="1"
+                grid:layout_gravity="center" />
 
 
             <TextView

--- a/app/src/main/res/layout/activity_db_management.xml
+++ b/app/src/main/res/layout/activity_db_management.xml
@@ -1,5 +1,4 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:grid="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,7 +9,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <android.support.v7.widget.GridLayout
+        <android.support.v7.widget.GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:grid="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/activity_vertical_margin"
@@ -29,8 +29,8 @@
             <Button
                 android:id="@+id/importDBButton"
                 android:text="Import DB"
-                grid:layout_column="1"
-                grid:layout_gravity="center" />
+                grid:layout_gravity="center"
+                grid:layout_column="1" />
 
 
             <TextView
@@ -49,13 +49,6 @@
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 grid:layout_columnSpan="2"
                 grid:layout_columnWeight="1" />
-
-            <Button
-                android:id="@+id/chooseDirectory"
-                android:text="Choose Directory"
-                grid:layout_columnSpan="2"
-                grid:layout_columnWeight="1"
-                grid:layout_gravity="center" />
 
 
             <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,13 @@
     <string name="prefs_title_all_day_heart_rate">All day heart rate measurement</string>
     <string name="preferences_hplus_settings">HPlus/Makibes settings</string>
 
+    <!-- Auto export preferences -->
+    <string name="pref_header_auto_export">Auto export</string>
+    <string name="pref_title_auto_export_enabled">Auto export enabled</string>
+    <string name="pref_title_auto_export_location">Export location</string>
+    <string name="pref_title_auto_export_interval">Export interval</string>
+    <string name="pref_summary_auto_export_interval">Export every %d hour</string>
+
     <string name="not_connected">Not connected</string>
     <string name="connecting">Connecting</string>
     <string name="connected">Connected</string>
@@ -523,4 +530,6 @@
     <string name="devicetype_exrizu_k8">Exrizu K8</string>
     <string name="devicetype_no1_f1">No.1 F1</string>
     <string name="devicetype_teclast_h30">Teclast H30</string>
+
+    <string name="choose_auto_export_location">Choose export location</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -311,6 +311,7 @@
     <string name="notif_battery_low_percent">%1$s battery left: %2$s%%</string>
     <string name="notif_battery_low_bigtext_last_charge_time">Last charge: %s \n</string>
     <string name="notif_battery_low_bigtext_number_of_charges">Number of charges: %s</string>
+    <string name="notif_export_failed_title">Export database failed! Please check your settings.</string>
     <string name="sleepchart_your_sleep">Your sleep</string>
     <string name="weeksleepchart_sleep_a_week">Sleep a week</string>
     <string name="weeksleepchart_today_sleep_description">Sleep today, target: %1$s</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -504,23 +504,22 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="database"
-        android:title="Database settings">
-        <Preference
-            android:key="export_location"
-            android:title="Database export location"
-            android:summary="%s" />
+        android:title="@string/pref_header_auto_export">
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="auto_export_enabled"
-            android:title="Enable periodic export" />
+            android:title="@string/pref_title_auto_export_enabled" />
+        <Preference
+            android:key="auto_export_location"
+            android:title="@string/pref_title_auto_export_location"
+            android:summary="%s" />
         <EditTextPreference
             android:inputType="number"
-            android:key="auto_export_period"
+            android:key="auto_export_interval"
             android:defaultValue="3"
             android:maxLength="3"
-            android:title="Export every n hours"
-            android:summary="%n"/>
+            android:title="@string/pref_title_auto_export_interval"
+            android:summary="@string/pref_summary_auto_export_interval"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:key="pref_key_development"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -101,13 +101,6 @@
             android:defaultValue="true"
             android:key="charts_allow_swipe"
             android:title="@string/pref_title_charts_swipe" />
-        <ListPreference
-            android:defaultValue="metric"
-            android:entries="@array/pref_entries_unit_system"
-            android:entryValues="@array/pref_values_unit_system"
-            android:key="measurement_system"
-            android:summary="%s"
-            android:title="@string/pref_title_unit_system" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="pref_key_datetime"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -101,6 +101,13 @@
             android:defaultValue="true"
             android:key="charts_allow_swipe"
             android:title="@string/pref_title_charts_swipe" />
+        <ListPreference
+            android:defaultValue="metric"
+            android:entries="@array/pref_entries_unit_system"
+            android:entryValues="@array/pref_values_unit_system"
+            android:key="measurement_system"
+            android:summary="%s"
+            android:title="@string/pref_title_unit_system" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="pref_key_datetime"
@@ -496,6 +503,25 @@
         </PreferenceScreen>
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:key="database"
+        android:title="Database settings">
+        <Preference
+            android:key="export_location"
+            android:title="Database export location"
+            android:summary="%s" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="auto_export_enabled"
+            android:title="Enable periodic export" />
+        <EditTextPreference
+            android:inputType="number"
+            android:key="auto_export_period"
+            android:defaultValue="3"
+            android:maxLength="3"
+            android:title="Export every n hours"
+            android:summary="%n"/>
+    </PreferenceCategory>
     <PreferenceCategory
         android:key="pref_key_development"
         android:title="@string/pref_header_development">


### PR DESCRIPTION
Hi, first a disclaimer, I don't regularly program in Java and even less so for Android.
I try to implement an automatic export/backup of the database. The idea is to be able to specify where the database should be written every nth hour or so. Then, a sync tool like Syncthing picks it up and transfers it elsewhere, I import it into Influx DB or whatever and make nice graphs using Grafana or something similar. I think it is related to #553.

I started to add preferences, added an broadcast receiver, schedule intents using the AlarmManager and extended the export to an arbitrary URI so that the DB can be exported to any location a DocumentProvider supports.

There is still one big problem and probably a lot of room for improvement of the code style.
I'm unable to display the location of the exported file properly, I only receive a display name from the provider but no path. Furthermore, if I use a CREATE_DOCUMENT intent I can't pick an already existing file, and if I use a OPEN_DOCUMENT intent I can't create a new file :(
This could be solver by using a traditional file picker, however I don't know how or more precisely, it seems this would require a third party library and I don't know which I would use.
However, using the new Storage Access Framework seems to be the better option anyway, as this would for example allow to write the file directly to Google Drive, Dropbox or Nextcloud/Owncloud.

I would be very happy if somebody could provide some help so that I can get this PR into a state where it can be merged. Please let me know what I should change and improve. (Some things I already know, like setting the summary of the new preferences, scheduling the intent again after reboot).

Todo
* [x] Reschedule export broadcast after boot
* [x] What happens to the DB management activity?
* [x] Test export failed notification
  