### PR TITLE
Improved notification text

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GB.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GB.java
@@ -86,7 +86,7 @@ public class GB {
         Boolean connected = device.isInitialized();
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
         builder.setContentTitle(deviceName)
-                .setTicker(deviceName + text)
+                .setTicker(deviceName + " - " + text)
                 .setContentText(text)
                 .setSmallIcon(connected ? R.drawable.ic_notification : R.drawable.ic_notification_disconnected)
                 .setContentIntent(getContentIntent(context))


### PR DESCRIPTION
Added a small spacer that makes the notification a lot nicer to read, before the device name and the text were just concatenated without any space in-between.