### PR TITLE
Fix crash when selecting automatic export interval

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
@@ -308,10 +308,10 @@ public class SettingsActivity extends AbstractSettingsActivity {
             public boolean onPreferenceChange(Preference preference, Object autoExportInterval) {
                 String summary = String.format(
                         getApplicationContext().getString(R.string.pref_summary_auto_export_interval),
-                        (int) autoExportInterval);
+                        Integer.valueOf((String) autoExportInterval));
                 preference.setSummary(summary);
                 boolean auto_export_enabled = GBApplication.getPrefs().getBoolean(GBPrefs.AUTO_EXPORT_ENABLED, false);
-                PeriodicExporter.sheduleAlarm(getApplicationContext(), (int) autoExportInterval, auto_export_enabled);
+                PeriodicExporter.sheduleAlarm(getApplicationContext(), Integer.valueOf((String) autoExportInterval), auto_export_enabled);
                 return true;
             }
         });


### PR DESCRIPTION
I made a mistake in the code for the periodic export :(
Gadgetbridge crashes when you try to change the export interval. This should fix it. Sorry.