### PR TITLE
Add ta marbutah to Arabic transliteration.

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/LanguageUtils.java
@@ -68,7 +68,7 @@ public class LanguageUtils {
             put('د', "d"); put('ذ', "th"); put('ر', "r"); put('ز', "z"); put('س', "s"); put('ش', "sh"); put('ص', "9");
             put('ض', "9'"); put('ط', "6"); put('ظ', "6'"); put('ع', "3"); put('غ', "3'"); put('ف', "f");
             put('ق', "q"); put('ك', "k"); put('ل', "l"); put('م', "m"); put('ن', "n"); put('ه', "h");
-            put('و', "w"); put('ي', "y"); put('ى', "a");
+            put('و', "w"); put('ي', "y"); put('ى', "a"); put('ﺓ', "");
             put('آ', "2"); put('ئ', "2"); put('إ', "2"); put('ؤ', "2"); put('أ', "2"); put('ء', "2");
 
             // Farsi

--- a/app/src/test/java/nodomain/freeyourgadget/gadgetbridge/test/LanguageUtilsTest.java
+++ b/app/src/test/java/nodomain/freeyourgadget/gadgetbridge/test/LanguageUtilsTest.java
@@ -39,7 +39,12 @@ public class LanguageUtilsTest extends TestBase {
         String pangram = "نص حكيم له سر قاطع وذو شأن عظيم مكتوب على ثوب أخضر ومغلف بجلد أزرق";
         String pangramExpected = "n9 7kym lh sr qa63 wthw sh2n 36'ym mktwb 3la thwb 259'r wm3'lf bjld 2zrq";
         String pangramActual = LanguageUtils.transliterate(pangram);
-        assertEquals("Arabic pangram transliteration failed", pangramExpected, pangramActual);
+        assertEquals("pangram transliteration failed", pangramExpected, pangramActual);
+
+        String taMarbutah = "ﺓ";
+        String taMarbutahExpected = "";
+        String taMarbutahActual = LanguageUtils.transliterate(taMarbutah);
+        assertEquals("ta marbutah transliteration failed", taMarbutahExpected, taMarbutahActual);
 
         String hamza = "ءأؤإئآ";
         String hamzaExpected = "222222";


### PR DESCRIPTION
Add ة, a normally-silent form of the letter ت that was missed when this
functionality was originally added.