### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.MEDIA_CONTENT_CONTROL" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <uses-permission android:name="cyanogenmod.permission.ACCESS_WEATHER_MANAGER" />

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
@@ -319,6 +319,8 @@ public class ControlCenterv2 extends AppCompatActivity
             wantedPermissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_DENIED)
             wantedPermissions.add(Manifest.permission.READ_CALENDAR);
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.MEDIA_CONTENT_CONTROL) == PackageManager.PERMISSION_DENIED)
+            wantedPermissions.add(Manifest.permission.MEDIA_CONTENT_CONTROL);
 
         if (!wantedPermissions.isEmpty())
             ActivityCompat.requestPermissions(this, wantedPermissions.toArray(new String[wantedPermissions.size()]), 0);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
@@ -319,8 +319,11 @@ public class ControlCenterv2 extends AppCompatActivity
             wantedPermissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_DENIED)
             wantedPermissions.add(Manifest.permission.READ_CALENDAR);
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.MEDIA_CONTENT_CONTROL) == PackageManager.PERMISSION_DENIED)
-            wantedPermissions.add(Manifest.permission.MEDIA_CONTENT_CONTROL);
+        try {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.MEDIA_CONTENT_CONTROL) == PackageManager.PERMISSION_DENIED)
+                wantedPermissions.add(Manifest.permission.MEDIA_CONTENT_CONTROL);
+        } catch (Exception ignored){
+        }
 
         if (!wantedPermissions.isEmpty())
             ActivityCompat.requestPermissions(this, wantedPermissions.toArray(new String[wantedPermissions.size()]), 0);


### PR DESCRIPTION
Should fix this crash on Samsung Galaxy S8+ (dream2qltesq), Android 8.0:
```java
java.lang.RuntimeException: 
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:3397)
  at android.app.ActivityThread.-wrap18 (Unknown Source)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1780)
  at android.os.Handler.dispatchMessage (Handler.java:105)
  at android.os.Looper.loop (Looper.java:164)
  at android.app.ActivityThread.main (ActivityThread.java:6938)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:327)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374)
Caused by: java.lang.SecurityException: 
  at android.os.Parcel.readException (Parcel.java:1958)
  at android.os.Parcel.readException (Parcel.java:1904)
  at android.media.session.ISessionManager$Stub$Proxy.getSessions (ISessionManager.java:255)
  at android.media.session.MediaSessionManager.getActiveSessionsForUser (MediaSessionManager.java:138)
  at android.media.session.MediaSessionManager.getActiveSessions (MediaSessionManager.java:118)
  at ee.aegrel.gadgetbridge.service.receivers.GBMusicControlReceiver.getAudioPlayer (GBMusicControlReceiver.java:110)
  at ee.aegrel.gadgetbridge.service.receivers.GBMusicControlReceiver.onReceive (GBMusicControlReceiver.java:79)
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:3390)
  at android.app.ActivityThread.-wrap18 (Unknown Source)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1780)
  at android.os.Handler.dispatchMessage (Handler.java:105)
  at android.os.Looper.loop (Looper.java:164)
  at android.app.ActivityThread.main (ActivityThread.java:6938)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:327)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374)
```

[Android documentation](https://developer.android.com/reference/android/media/session/MediaSessionManager.html#getActiveSessions(android.content.ComponentName)) says that [android.permission.MEDIA_CONTENT_CONTROL](https://developer.android.com/reference/android/Manifest.permission.html#MEDIA_CONTENT_CONTROL) is required to call `getActiveSessions(ComponentName notificationListener)` used in in [GBMusicControlReceiver :110](https://github.com/Freeyourgadget/Gadgetbridge/blob/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBMusicControlReceiver.java#L110)