### PR TITLE
Fixed issue on P8 Lite and Power Four with BluetoothDevice getName() starting to return null

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/DeviceHelper.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/DeviceHelper.java
@@ -253,8 +253,11 @@ public class DeviceHelper {
         List<GBDevice> result = new ArrayList<>(pairedDevices.size());
         DeviceHelper deviceHelper = DeviceHelper.getInstance();
         for (BluetoothDevice pairedDevice : pairedDevices) {
-            if (pairedDevice.getName() != null && (pairedDevice.getName().startsWith("Pebble-LE ") || pairedDevice.getName().startsWith("Pebble Time LE "))) {
-                continue; // ignore LE Pebble (this is part of the main device now (volatileAddress)
+            String pairedDeviceName = pairedDevice.getName();
+            if (pairedDeviceName != null){
+                if(pairedDeviceName.startsWith("Pebble-LE ") || pairedDeviceName.startsWith("Pebble Time LE ")) {
+                    continue; // ignore LE Pebble (this is part of the main device now (volatileAddress)
+                }
             }
             GBDevice device = deviceHelper.toSupportedDevice(pairedDevice);
             if (device != null) {


### PR DESCRIPTION
Tries to fix this crash (has occurred twice, once on P8 Lite and once on Power Four:
```java
java.lang.RuntimeException: 
  at android.app.ActivityThread.handleBindApplication (ActivityThread.java:4805)
  at android.app.ActivityThread.access$1600 (ActivityThread.java:165)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1437)
  at android.os.Handler.dispatchMessage (Handler.java:102)
  at android.os.Looper.loop (Looper.java:150)
  at android.app.ActivityThread.main (ActivityThread.java:5621)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:794)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:684)
Caused by: java.lang.NullPointerException: 
  at ee.aegrel.gadgetbridge.util.DeviceHelper.getBondedDevices (DeviceHelper.java:257)
  at ee.aegrel.gadgetbridge.util.DeviceHelper.getAvailableDevices (DeviceHelper.java:130)
  at ee.aegrel.gadgetbridge.devices.DeviceManager.refreshPairedDevices (DeviceManager.java:156)
  at ee.aegrel.gadgetbridge.devices.DeviceManager.<init> (DeviceManager.java:123)
  at ee.aegrel.gadgetbridge.GBApplication.onCreate (GBApplication.java:167)
  at android.app.Instrumentation.callApplicationOnCreate (Instrumentation.java:1015)
  at android.app.ActivityThread.handleBindApplication (ActivityThread.java:4793)
  at android.app.ActivityThread.access$1600 (ActivityThread.java:165)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1437)
  at android.os.Handler.dispatchMessage (Handler.java:102)
  at android.os.Looper.loop (Looper.java:150)
  at android.app.ActivityThread.main (ActivityThread.java:5621)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:794)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:684)
```

I considered it being Proguard's misdoing, but I heavily doubt it would get short-circuit evaluation wrong (I think I'd be seeing it a lot more then), I'm suspecting too frequent polling just sometimes returns null. .-.