### PR TITLE
Auto sync feature

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/GBApplication.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/GBApplication.java
@@ -64,6 +64,7 @@ import nodomain.freeyourgadget.gadgetbridge.impl.GBDeviceService;
 import nodomain.freeyourgadget.gadgetbridge.model.ActivityUser;
 import nodomain.freeyourgadget.gadgetbridge.model.DeviceService;
 import nodomain.freeyourgadget.gadgetbridge.service.NotificationCollectorMonitorService;
+import nodomain.freeyourgadget.gadgetbridge.service.receivers.GBAutoFetchReceiver;
 import nodomain.freeyourgadget.gadgetbridge.util.AndroidUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.FileUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
@@ -195,6 +196,10 @@ public class GBApplication extends Application {
                 registerReceiver(bluetoothStateChangeReceiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
             }
             startService(new Intent(this, NotificationCollectorMonitorService.class));
+        }
+
+        if (prefs.getBoolean("auto_fetch_enabled", false)) {
+            registerReceiver(new GBAutoFetchReceiver(), new IntentFilter("android.intent.action.USER_PRESENT"));
         }
     }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBAutoFetchReceiver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBAutoFetchReceiver.java
@@ -3,37 +3,28 @@ package nodomain.freeyourgadget.gadgetbridge.service.receivers;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-
 import java.util.List;
 
 import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.devices.DeviceCoordinator;
-import nodomain.freeyourgadget.gadgetbridge.devices.DeviceManager;
 import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
 import nodomain.freeyourgadget.gadgetbridge.model.RecordedDataTypes;
 import nodomain.freeyourgadget.gadgetbridge.util.DeviceHelper;
 
-import static nodomain.freeyourgadget.gadgetbridge.util.GB.log;
 
 public class GBAutoFetchReceiver extends BroadcastReceiver {
         @Override
         public void onReceive(Context context, Intent intent) {
-            log("screen on!", 3, null);
-            List<GBDevice> devices = new DeviceManager(context).getDevices();
+            GBApplication application = (GBApplication) context;
+            List<GBDevice> devices = application.getDeviceManager().getDevices();
             for (int i = 0; i < devices.size(); i++) {
                 GBDevice device = devices.get(i);
-
-                log(device.toString(), 3, null);
                 // Will show that the device is not connected even when the device is connected
-//                if (device.isConnected() && device.isInitialized()) {
+                if (device.isConnected() && device.isInitialized()) {
                     DeviceCoordinator coordinator = DeviceHelper.getInstance().getCoordinator(device);
-                    log(device.getName() + " is connected and initialized!", 3, null);
                     if (coordinator.supportsActivityDataFetching() && !device.isBusy()) {
-                        log("about to transfer activity!", 3, null);
-                        GBApplication.deviceService().onFetchRecordedData(RecordedDataTypes.TYPE_ACTIVITY);
-//                    } else {
-//                        log("Device is not connected!", 3, null);
-//                    }
+                        application.deviceService().onFetchRecordedData(RecordedDataTypes.TYPE_ACTIVITY);
+                    }
                 }
             }
         }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBAutoFetchReceiver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBAutoFetchReceiver.java
@@ -1,0 +1,41 @@
+package nodomain.freeyourgadget.gadgetbridge.service.receivers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import java.util.List;
+
+import nodomain.freeyourgadget.gadgetbridge.GBApplication;
+import nodomain.freeyourgadget.gadgetbridge.devices.DeviceCoordinator;
+import nodomain.freeyourgadget.gadgetbridge.devices.DeviceManager;
+import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
+import nodomain.freeyourgadget.gadgetbridge.model.RecordedDataTypes;
+import nodomain.freeyourgadget.gadgetbridge.util.DeviceHelper;
+
+import static nodomain.freeyourgadget.gadgetbridge.util.GB.log;
+
+public class GBAutoFetchReceiver extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            log("screen on!", 3, null);
+            List<GBDevice> devices = new DeviceManager(context).getDevices();
+            for (int i = 0; i < devices.size(); i++) {
+                GBDevice device = devices.get(i);
+
+                log(device.toString(), 3, null);
+                // Will show that the device is not connected even when the device is connected
+//                if (device.isConnected() && device.isInitialized()) {
+                    DeviceCoordinator coordinator = DeviceHelper.getInstance().getCoordinator(device);
+                    log(device.getName() + " is connected and initialized!", 3, null);
+                    if (coordinator.supportsActivityDataFetching() && !device.isBusy()) {
+                        log("about to transfer activity!", 3, null);
+                        GBApplication.deviceService().onFetchRecordedData(RecordedDataTypes.TYPE_ACTIVITY);
+//                    } else {
+//                        log("Device is not connected!", 3, null);
+//                    }
+                }
+            }
+        }
+    }
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,9 @@
     <string name="pref_title_auto_export_interval">Export interval</string>
     <string name="pref_summary_auto_export_interval">Export every %d hour</string>
 
+    <!-- Auto fetch activity preferences -->
+    <string name="pref_auto_fetch">Auto fetch activity data</string>
+
     <string name="not_connected">Not connected</string>
     <string name="connecting">Connecting</string>
     <string name="connected">Connected</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -533,7 +533,7 @@
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="auto_fetch_enabled"
-            android:title="Auto fetch enabled" />
+            android:title="@string/pref_auto_fetch" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -28,12 +28,12 @@
             android:defaultValue="@string/pref_theme_value_light"
             android:summary="%s" />
         <ListPreference
-            android:key="language"
-            android:title="@string/pref_title_language"
+            android:defaultValue="default"
             android:entries="@array/pref_language_options"
             android:entryValues="@array/pref_language_values"
-            android:defaultValue="default"
-            android:summary="%s" />
+            android:key="language"
+            android:summary="%s"
+            android:title="@string/pref_title_language" />
         <ListPreference
             android:defaultValue="metric"
             android:entries="@array/pref_entries_unit_system"
@@ -527,6 +527,15 @@
             android:title="@string/pref_title_auto_export_interval"
             android:summary="@string/pref_summary_auto_export_interval"/>
     </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="Auto fetch">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="auto_fetch_enabled"
+            android:title="Auto fetch enabled" />
+    </PreferenceCategory>
+
     <PreferenceCategory
         android:key="pref_key_development"
         android:title="@string/pref_header_development">


### PR DESCRIPTION
#1116, requested a feature which makes the application able to automatically refresh the activity data without the need to open the application. I think this might be a possible solution, where the activity data is transferred when the screen is unlocked. There might be a possibility for improvement, where the snackbar tooltip could be removed, and a period between the syncs (since this will always update, when the phone is unlocked). 

I've been using this patch for a few weeks with the MiBand2 and it seems to work without major problems.