### PR TITLE
Allow the user to decide the interval between autofetches

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
@@ -326,6 +326,26 @@ public class SettingsActivity extends AbstractSettingsActivity {
             }
         });
 
+        pref = findPreference("auto_fetch_interval_limit");
+        pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object autoFetchInterval) {
+                String summary = String.format(
+                        getApplicationContext().getString(R.string.pref_auto_fetch_limit_fetches_summary),
+                        Integer.valueOf((String) autoFetchInterval));
+                preference.setSummary(summary);
+                return true;
+            }
+        });
+
+        int autoFetchInterval = GBApplication.getPrefs().getInt("auto_fetch_interval_limit", 0);
+        summary = String.format(
+                getApplicationContext().getString(R.string.pref_auto_fetch_limit_fetches_summary),
+                (int) autoFetchInterval);
+        pref.setSummary(summary);
+
+
+
         final Preference displayPages = findPreference("bip_display_items");
         displayPages.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
@@ -680,7 +680,7 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 }
             }
             if (GBApplication.getPrefs().getBoolean("auto_fetch_enabled", false) &&
-                    coordinator != null && coordinator.supportsActivityDataFetching()) {
+                    coordinator != null && coordinator.supportsActivityDataFetching() && mGBAutoFetchReceiver == null) {
                 mGBAutoFetchReceiver = new GBAutoFetchReceiver();
                 registerReceiver(mGBAutoFetchReceiver, new IntentFilter("android.intent.action.USER_PRESENT"));
             }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBAutoFetchReceiver.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/receivers/GBAutoFetchReceiver.java
@@ -20,20 +20,22 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.time.DateUtils;
+import java.util.Date;
 
 import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.model.RecordedDataTypes;
 
 
 public class GBAutoFetchReceiver extends BroadcastReceiver {
-    private static final Logger LOG = LoggerFactory.getLogger(GBAutoFetchReceiver.class);
+    private Date lastSync = new Date();
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        //LOG.info("User is present!");
-        GBApplication.deviceService().onFetchRecordedData(RecordedDataTypes.TYPE_ACTIVITY);
+        Date nextSync = DateUtils.addMinutes(lastSync, GBApplication.getPrefs().getInt("auto_fetch_interval_limit", 0));
+        if (nextSync.before(new Date())) {
+            GBApplication.deviceService().onFetchRecordedData(RecordedDataTypes.TYPE_ACTIVITY);
+            lastSync = new Date();
+        }
     }
 }
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,6 +202,8 @@
     <!-- Auto fetch activity preferences -->
     <string name="pref_auto_fetch">Auto fetch activity data</string>
     <string name="pref_auto_fetch_summary">Fetch happens upon screen unlock. Only works if a lock mechanism is set!</string>
+    <string name="pref_auto_fetch_limit_fetches">Minimum time between fetches</string>
+    <string name="pref_auto_fetch_limit_fetches_summary">Fetches every %d minutes</string>
 
     <string name="not_connected">Not connected</string>
     <string name="connecting">Connecting</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -535,6 +535,13 @@
             android:key="auto_fetch_enabled"
             android:title="@string/pref_auto_fetch"
             android:summary="@string/pref_auto_fetch_summary"/>
+        <EditTextPreference
+            android:inputType="number"
+            android:key="auto_fetch_interval_limit"
+            android:defaultValue="0"
+            android:maxLength="3"
+            android:title="@string/pref_auto_fetch_limit_fetches"
+            android:summary="@string/pref_auto_fetch_limit_fetches_summary"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
So this is a follow up from #1127, with a added option to block fetches within a time-period. 

The phone can be unlocked frequently, which would lead to GadgetBridge to fetch the activity data every time. This patch will disable the fetch for a period of time (set by the user). Also discovered that there was multiple GBAutoFetchReceiver active for one device, which should be removed now. 