### PR TITLE
added ability to connect to the current DeviceSupport

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
@@ -31,6 +31,7 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Binder;
 import android.os.Handler;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
@@ -751,9 +752,15 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
         }
     }
 
+    public class CommunicationServiceBinder extends Binder{
+        public DeviceSupport getDeviceSupport(){
+            return ((ServiceDeviceSupport)DeviceCommunicationService.this.mDeviceSupport).getDelegate();
+        }
+    }
+
     @Override
     public IBinder onBind(Intent intent) {
-        return null;
+        return new CommunicationServiceBinder();
     }
 
     @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/ServiceDeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/ServiceDeviceSupport.java
@@ -62,6 +62,10 @@ public class ServiceDeviceSupport implements DeviceSupport {
         this.flags = flags;
     }
 
+    public DeviceSupport getDelegate() {
+        return delegate;
+    }
+
     @Override
     public void setContext(GBDevice gbDevice, BluetoothAdapter btAdapter, Context context) {
         delegate.setContext(gbDevice, btAdapter, context);


### PR DESCRIPTION
By binding the DeviceCommunicationService a binder object can now be acquired,
which then can be used to get a reference to the currently responsible DeviceSupport.

In my [example](https://github.com/dakhnod/Gadgetbridge/blob/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/qhybrid/ConfigActivity.java#L186) this is done from a random activity to interact with the QHybridSupport class and [get the Device Vibration Strength](https://github.com/dakhnod/Gadgetbridge/blob/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/qhybrid/ConfigActivity.java#L129), which is handled [here](https://github.com/dakhnod/Gadgetbridge/blob/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/qhybrid/QHybridSupport.java#L105).

I tried to come up with a way of communicating with the DeviceSupport from basically any point in the app, and this is the best i could come up with.
Please enlighten me if there is another method of archieving the same, in my case to call that getVibrationStrength() method.