### PR TITLE
Mi Band 3: Change display items

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
@@ -405,8 +405,6 @@ public class SettingsActivity extends AbstractSettingsActivity {
             }
         });
 
-
-        /*
         final Preference miBand3DisplayItems = findPreference("miband3_display_items");
         miBand3DisplayItems.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
@@ -420,7 +418,6 @@ public class SettingsActivity extends AbstractSettingsActivity {
                 return true;
             }
         });
-        */
 
         final Preference corDisplayItems = findPreference("cor_display_items");
         corDisplayItems.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/huami/miband3/MiBand3Service.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/huami/miband3/MiBand3Service.java
@@ -22,7 +22,7 @@ import static nodomain.freeyourgadget.gadgetbridge.devices.huami.HuamiService.EN
 import static nodomain.freeyourgadget.gadgetbridge.devices.huami.HuamiService.ENDPOINT_DISPLAY_ITEMS;
 
 public class MiBand3Service {
-    public static final byte[] COMMAND_CHANGE_SCREENS = new byte[]{ENDPOINT_DISPLAY_ITEMS, DISPLAY_ITEM_BIT_CLOCK, 0x30, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    public static final byte[] COMMAND_CHANGE_SCREENS = new byte[]{ENDPOINT_DISPLAY_ITEMS, DISPLAY_ITEM_BIT_CLOCK, 0x30, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00};
     public static final byte[] COMMAND_ENABLE_BAND_SCREEN_UNLOCK = new byte[]{ENDPOINT_DISPLAY, 0x16, 0x00, 0x01};
     public static final byte[] COMMAND_DISABLE_BAND_SCREEN_UNLOCK = new byte[]{ENDPOINT_DISPLAY, 0x16, 0x00, 0x00};
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/miband3/MiBand3Support.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/miband3/MiBand3Support.java
@@ -43,33 +43,46 @@ public class MiBand3Support extends AmazfitBipSupport {
     private static final Logger LOG = LoggerFactory.getLogger(MiBand3Support.class);
 
     @Override
-    protected AmazfitBipSupport setDisplayItems(TransactionBuilder builder) {
-        if (true) {
-            return this;
-        }
-
+    protected MiBand3Support setDisplayItems(TransactionBuilder builder) {
         Prefs prefs = GBApplication.getPrefs();
         Set<String> pages = prefs.getStringSet("miband3_display_items", null);
         LOG.info("Setting display items to " + (pages == null ? "none" : pages));
         byte[] command = MiBand3Service.COMMAND_CHANGE_SCREENS.clone();
 
+        byte pos = 1;
         if (pages != null) {
-            if (pages.contains("notifications")) {
-                command[1] |= 0x02;
-            }
-            if (pages.contains("weather")) {
-                command[1] |= 0x04;
-            }
-            if (pages.contains("more")) {
-                command[1] |= 0x10;
-            }
-            if (pages.contains("status")) {
-                command[1] |= 0x20;
-            }
-            if (pages.contains("heart_rate")) {
-                command[1] |= 0x40;
+            for (String page : pages) {
+                switch (page) {
+                    case "notifications":
+                        command[1] |= 0x02;
+                        command[4] = pos++;
+                        break;
+                    case "weather":
+                        command[1] |= 0x04;
+                        command[5] = pos++;
+                        break;
+                    case "more":
+                        command[1] |= 0x10;
+                        command[7] = pos++;
+                        break;
+                    case "status":
+                        command[1] |= 0x20;
+                        command[8] = pos++;
+                        break;
+                    case "heart_rate":
+                        command[1] |= 0x40;
+                        command[9] = pos++;
+                        break;
+                }
             }
         }
+
+        for (int i = 4; i <= 9; i++) {
+            if (command[i] == 0) {
+                command[i] = pos++;
+            }
+        }
+
         builder.write(getCharacteristic(HuamiService.UUID_CHARACTERISTIC_3_CONFIGURATION), command);
 
         return this;

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -217,7 +217,6 @@
                 android:key="mi3_band_screen_unlock"
                 android:summary="@string/mi3_prefs_band_screen_unlock_summary"
                 android:title="@string/mi3_prefs_band_screen_unlock" />
-<!--
             <MultiSelectListPreference
                 android:dialogTitle="@string/mi2_prefs_display_items"
                 android:defaultValue="@array/pref_miband3_display_items_default"
@@ -226,7 +225,6 @@
                 android:key="miband3_display_items"
                 android:summary="@string/mi2_prefs_display_items_summary"
                 android:title="@string/mi2_prefs_display_items"/>
--->
         </PreferenceScreen>
         <PreferenceScreen
             android:icon="@drawable/ic_device_hplus"


### PR DESCRIPTION
Allows changing the Mi Band 3 display items.

The order currently depends on the iteration order of the `Set<String> pages`. The function already allows for the order to be set if a `List<String>` is provided with the proper order, for example, but I won't have the time to implement the UI for that any time soon, so this PR at least allows for the selection.

The 7th byte of COMMAND_CHANGE_SCREENS is always 0x06 (last position) probably reserved for some extra screen in the future, I tried to enable it without success.