### PR TITLE
Refresh paired devices from UI thread

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
@@ -87,7 +87,12 @@ public class ControlCenterv2 extends AppCompatActivity
                     finish();
                     break;
                 case DeviceManager.ACTION_DEVICES_CHANGED:
-                    refreshPairedDevices();
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            refreshPairedDevices();
+                        }
+                    });
                     break;
             }
         }


### PR DESCRIPTION
Fixes CalledFromWrongThreadException when connecting to a device.

Stack trace:

```
08-17 18:21:13.515 16690-16727/nodomain.freeyourgadget.gadgetbridge E/nodomain.freeyourgadget.gadgetbridge.service.btle.BtLEQueue: onCharacteristicRead: Only the original thread that created a view hierarchy can touch its views.android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
    	at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:7344) ~[na:0.0]
    	at android.view.ViewRootImpl.requestLayout(ViewRootImpl.java:1176) ~[na:0.0]
    	at android.view.View.requestLayout(View.java:22015) ~[na:0.0]
    	at android.view.View.requestLayout(View.java:22015) ~[na:0.0]
    	at android.view.View.requestLayout(View.java:22015) ~[na:0.0]
    	at android.view.View.requestLayout(View.java:22015) ~[na:0.0]
    	at android.view.View.requestLayout(View.java:22015) ~[na:0.0]
    	at android.view.View.requestLayout(View.java:22015) ~[na:0.0]
    	at android.support.v4.widget.DrawerLayout.requestLayout(DrawerLayout.java:1243) ~[na:0.0]
    	at android.view.View.requestLayout(View.java:22015) ~[na:0.0]
    	at android.view.View.requestLayout(View.java:22015) ~[na:0.0]
    	at android.widget.RelativeLayout.requestLayout(RelativeLayout.java:360) ~[na:0.0]
    	at android.view.View.requestLayout(View.java:22015) ~[na:0.0]
    	at android.support.v7.widget.RecyclerView.requestLayout(RecyclerView.java:4090) ~[na:0.0]
    	at android.support.v7.widget.RecyclerView$RecyclerViewDataObserver.onChanged(RecyclerView.java:5182) ~[na:0.0]
    	at android.support.v7.widget.RecyclerView$AdapterDataObservable.notifyChanged(RecyclerView.java:11785) ~[na:0.0]
    	at android.support.v7.widget.RecyclerView$Adapter.notifyDataSetChanged(RecyclerView.java:6961) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.activities.ControlCenterv2.refreshPairedDevices(ControlCenterv2.java:290) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.activities.ControlCenterv2.access$000(ControlCenterv2.java:63) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.activities.ControlCenterv2$1.onReceive(ControlCenterv2.java:93) ~[na:0.0]
    	at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:311) ~[na:0.0]
    	at android.support.v4.content.LocalBroadcastManager.sendBroadcastSync(LocalBroadcastManager.java:289) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.AbstractBleProfile.notify(AbstractBleProfile.java:58) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfoProfile.handleSoftwareRevision(DeviceInfoProfile.java:144) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfoProfile.onCharacteristicRead(DeviceInfoProfile.java:91) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSupport.onCharacteristicRead(AbstractBTLEDeviceSupport.java:266) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.service.devices.huami.HuamiSupport.onCharacteristicRead(HuamiSupport.java:1239) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEOperation.onCharacteristicRead(AbstractBTLEOperation.java:175) ~[na:0.0]
    	at nodomain.freeyourgadget.gadgetbridge.service.btle.BtLEQueue$InternalGattCallback.onCharacteristicRead(BtLEQueue.java:427) ~[na:0.0]
    	at android.bluetooth.BluetoothGatt$1$6.run(BluetoothGatt.java:364) ~[na:0.0]
    	at android.bluetooth.BluetoothGatt.runOrQueueCallback(BluetoothGatt.java:725) ~[na:0.0]
    	at android.bluetooth.BluetoothGatt.-wrap0(Unknown Source:0) ~[na:0.0]
    	at android.bluetooth.BluetoothGatt$1.onCharacteristicRead(BluetoothGatt.java:358) ~[na:0.0]
    	at android.bluetooth.IBluetoothGattCallback$Stub.onTransact(IBluetoothGattCallback.java:124) ~[na:0.0]
    	at android.os.Binder.execTransact(Binder.java:697) ~[na:0.0]
```