### PR TITLE
Support minimum time between notifications

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -387,4 +387,28 @@
         <item>1800</item>
         <item>3600</item>
     </string-array>
+
+    <string-array name="notifications_timeout">
+        <item>@string/no_limit</item>
+        <item>@string/seconds_5</item>
+        <item>@string/seconds_10</item>
+        <item>@string/seconds_20</item>
+        <item>@string/seconds_30</item>
+        <item>@string/minutes_1</item>
+        <item>@string/minutes_5</item>
+        <item>@string/minutes_10</item>
+        <item>@string/minutes_30</item>
+    </string-array>
+    <string-array name="notifications_timeout_values">
+        <item>0</item>
+        <item>5</item>
+        <item>10</item>
+        <item>20</item>
+        <item>30</item>
+        <item>60</item>
+        <item>300</item>
+        <item>600</item>
+        <item>1800</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="pref_title_notifications_repetitions">Repetitions</string>
     <string name="pref_title_notifications_call">Phone Calls</string>
     <string name="pref_title_notifications_sms">SMS</string>
+    <string name="pref_title_notifications_timeout">Minimum time between notifications</string>
     <string name="pref_title_notifications_pebblemsg">Pebble Messages</string>
     <string name="pref_summary_notifications_pebblemsg">Support for apps that send notifications to the Pebble via PebbleKit.</string>
     <string name="pref_title_notifications_generic">Generic notification support</string>
@@ -368,6 +369,15 @@
     <string name="heart_rate">Heart rate</string>
     <string name="battery">Battery</string>
 
+    <string name="no_limit">No limit</string>
+    <string name="seconds_5">5 seconds</string>
+    <string name="seconds_10">10 seconds</string>
+    <string name="seconds_20">20 seconds</string>
+    <string name="seconds_30">30 seconds</string>
+    <string name="minutes_1">1 minute</string>
+    <string name="minutes_5">5 minutes</string>
+    <string name="minutes_10">10 minutes</string>
+    <string name="minutes_30">30 minutes</string>
 
     <string name="liveactivity_live_activity">Live activity</string>
     <string name="weeksteps_today_steps_description">Steps today, target: %1$s</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -155,6 +155,14 @@
             android:key="notifications_generic_whenscreenon"
             android:title="@string/pref_title_whenscreenon" />
 
+        <ListPreference
+            android:defaultValue="0"
+            android:entries="@array/notifications_timeout"
+            android:entryValues="@array/notifications_timeout_values"
+            android:key="notifications_timeout"
+            android:title="@string/pref_title_notifications_timeout"
+            android:summary="%s" />
+
         <CheckBoxPreference
             android:layout="@layout/preference_checkbox"
             android:defaultValue="false"


### PR DESCRIPTION
Simple implementation that allows the user to specify a minimum time between notifications, preventing spam from chat apps.

Possible future improvements: 
- Per-app configuration?
- Reset on screen on? (optionally)
