### PR TITLE
Apps: add p≡p as generic email app

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/AppNotificationType.java
@@ -39,6 +39,7 @@ public class AppNotificationType extends HashMap<String, NotificationType> {
         put("com.imaeses.squeaky", NotificationType.GENERIC_EMAIL);
         put("com.android.email", NotificationType.GENERIC_EMAIL);
         put("ch.protonmail.android", NotificationType.GENERIC_EMAIL);
+        put("security.pEp", NotificationType.GENERIC_EMAIL);
 
         // Generic SMS
         put("com.moez.QKSMS", NotificationType.GENERIC_SMS);


### PR DESCRIPTION
Hello,

This very small PR adds support for p≡p application.

This app is a fork of K9 Mail with a slightly different design and a
built-in security integration feature.

More details: https://f-droid.org/en/packages/security.pEp/

The goal is to see the email icon when receiving this kind of
notifications.

Cheers,
Matt