### PR TITLE
notif: sanitize strings set by external apps

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -351,6 +351,11 @@ public class NotificationListener extends NotificationListenerService {
         GBApplication.deviceService().onNotification(notificationSpec);
     }
 
+    // Strip Unicode control sequences: some apps like Telegram add a lot of them for unknown reasons
+    private String sanitizeUnicode(String orig) {
+        return orig.replaceAll("\\p{C}", "");
+    }
+
     private void dissectNotificationTo(Notification notification, NotificationSpec notificationSpec, boolean preferBigText) {
 
         Bundle extras = NotificationCompat.getExtras(notification);
@@ -359,7 +364,7 @@ public class NotificationListener extends NotificationListenerService {
 
         CharSequence title = extras.getCharSequence(Notification.EXTRA_TITLE);
         if (title != null) {
-            notificationSpec.title = title.toString();
+            notificationSpec.title = sanitizeUnicode(title.toString());
         }
 
         CharSequence contentCS = null;
@@ -369,7 +374,7 @@ public class NotificationListener extends NotificationListenerService {
             contentCS = extras.getCharSequence(NotificationCompat.EXTRA_TEXT);
         }
         if (contentCS != null) {
-            notificationSpec.body = contentCS.toString();
+            notificationSpec.body = sanitizeUnicode(contentCS.toString());
         }
 
     }


### PR DESCRIPTION
It seems some apps like Telegram add a lot of Unicode Control sequences
for unknown reasons. Because these strings are set by external apps, it
is safer to sanitize them. For the moment, only Unicode control
sequences are stripped.

Fixes: #1344