### PR TITLE
notif: convert emoji's to supported chars

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     implementation "org.cyanogenmod:platform.sdk:6.0"
     implementation 'com.jaredrummler:colorpicker:1.0.2'
 //    implementation project(":DaoCore")
+    implementation 'com.github.wax911:android-emojify:0.1.7'
 }
 
 preBuild.dependsOn(":GBDaoGenerator:genSources")

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/GBApplication.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/GBApplication.java
@@ -53,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import io.wax911.emojify.EmojiManager;
 import nodomain.freeyourgadget.gadgetbridge.database.DBHandler;
 import nodomain.freeyourgadget.gadgetbridge.database.DBHelper;
 import nodomain.freeyourgadget.gadgetbridge.database.DBOpenHelper;
@@ -197,6 +198,8 @@ public class GBApplication extends Application {
             }
             startService(new Intent(this, NotificationCollectorMonitorService.class));
         }
+
+        EmojiManager.initEmojiData(getApplicationContext());
     }
 
     @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/AbstractDeviceCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/AbstractDeviceCoordinator.java
@@ -149,4 +149,7 @@ public abstract class AbstractDeviceCoordinator implements DeviceCoordinator {
     public int[] getColorPresets() {
         return new int[0];
     }
+
+    @Override
+    public boolean supportsUnicodeEmojis() { return false; }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/DeviceCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/DeviceCoordinator.java
@@ -278,4 +278,9 @@ public interface DeviceCoordinator {
      */
     @NonNull
     int[] getColorPresets();
+
+    /**
+     * Indicates whether the device supports unicode emojis.
+     */
+    boolean supportsUnicodeEmojis();
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/huami/amazfitcor/AmazfitCorCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/huami/amazfitcor/AmazfitCorCoordinator.java
@@ -73,4 +73,7 @@ public class AmazfitCorCoordinator extends HuamiCoordinator {
     public boolean supportsMusicInfo() {
         return true;
     }
+
+    @Override
+    public boolean supportsUnicodeEmojis() { return true; }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/pebble/PebbleCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/pebble/PebbleCoordinator.java
@@ -175,4 +175,7 @@ public class PebbleCoordinator extends AbstractDeviceCoordinator {
     public boolean supportsMusicInfo() {
         return true;
     }
+
+    @Override
+    public boolean supportsUnicodeEmojis() { return true; }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
@@ -73,6 +73,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.NotificationType;
 import nodomain.freeyourgadget.gadgetbridge.model.WeatherSpec;
 import nodomain.freeyourgadget.gadgetbridge.service.receivers.GBAutoFetchReceiver;
 import nodomain.freeyourgadget.gadgetbridge.util.DeviceHelper;
+import nodomain.freeyourgadget.gadgetbridge.util.EmojiConverter;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.GBPrefs;
 import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
@@ -174,6 +175,7 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
     private DeviceSupportFactory mFactory;
     private GBDevice mGBDevice = null;
     private DeviceSupport mDeviceSupport;
+    private DeviceCoordinator mCoordinator = null;
 
     private PhoneCallReceiver mPhoneCallReceiver = null;
     private SMSReceiver mSMSReceiver = null;
@@ -225,8 +227,9 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 GBDevice device = intent.getParcelableExtra(GBDevice.EXTRA_DEVICE);
                 if (mGBDevice != null && mGBDevice.equals(device)) {
                     mGBDevice = device;
+                    mCoordinator = DeviceHelper.getInstance().getCoordinator(device);
                     boolean enableReceivers = mDeviceSupport != null && (mDeviceSupport.useAutoConnect() || mGBDevice.isInitialized());
-                    setReceiversEnableState(enableReceivers, mGBDevice.isInitialized(), DeviceHelper.getInstance().getCoordinator(device));
+                    setReceiversEnableState(enableReceivers, mGBDevice.isInitialized(), mCoordinator);
                 } else {
                     LOG.error("Got ACTION_DEVICE_CHANGED from unexpected device: " + device);
                 }
@@ -351,6 +354,20 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
         return START_STICKY;
     }
 
+    /**
+     * @param text: original text
+     * @return 'text' or a new String without non supported chars like emoticons, etc.
+     */
+    private String sanitizeNotifText(String text) {
+        if (text == null || text.length() == 0)
+            return text;
+
+        if (!mCoordinator.supportsUnicodeEmojis())
+            return EmojiConverter.convertUnicodeEmojiToAscii(text);
+
+        return text;
+    }
+
     private void handleAction(Intent intent, String action, Prefs prefs) {
         switch (action) {
             case ACTION_REQUEST_DEVICEINFO:
@@ -360,10 +377,10 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 int desiredId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1);
                 NotificationSpec notificationSpec = new NotificationSpec(desiredId);
                 notificationSpec.phoneNumber = intent.getStringExtra(EXTRA_NOTIFICATION_PHONENUMBER);
-                notificationSpec.sender = intent.getStringExtra(EXTRA_NOTIFICATION_SENDER);
-                notificationSpec.subject = intent.getStringExtra(EXTRA_NOTIFICATION_SUBJECT);
-                notificationSpec.title = intent.getStringExtra(EXTRA_NOTIFICATION_TITLE);
-                notificationSpec.body = intent.getStringExtra(EXTRA_NOTIFICATION_BODY);
+                notificationSpec.sender = sanitizeNotifText(intent.getStringExtra(EXTRA_NOTIFICATION_SENDER));
+                notificationSpec.subject = sanitizeNotifText(intent.getStringExtra(EXTRA_NOTIFICATION_SUBJECT));
+                notificationSpec.title = sanitizeNotifText(intent.getStringExtra(EXTRA_NOTIFICATION_TITLE));
+                notificationSpec.body = sanitizeNotifText(intent.getStringExtra(EXTRA_NOTIFICATION_BODY));
                 notificationSpec.sourceName = intent.getStringExtra(EXTRA_NOTIFICATION_SOURCENAME);
                 notificationSpec.type = (NotificationType) intent.getSerializableExtra(EXTRA_NOTIFICATION_TYPE);
                 notificationSpec.attachedActions = (ArrayList<NotificationSpec.Action>) intent.getSerializableExtra(EXTRA_NOTIFICATION_ACTIONS);
@@ -404,9 +421,9 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 calendarEventSpec.type = intent.getByteExtra(EXTRA_CALENDAREVENT_TYPE, (byte) -1);
                 calendarEventSpec.timestamp = intent.getIntExtra(EXTRA_CALENDAREVENT_TIMESTAMP, -1);
                 calendarEventSpec.durationInSeconds = intent.getIntExtra(EXTRA_CALENDAREVENT_DURATION, -1);
-                calendarEventSpec.title = intent.getStringExtra(EXTRA_CALENDAREVENT_TITLE);
-                calendarEventSpec.description = intent.getStringExtra(EXTRA_CALENDAREVENT_DESCRIPTION);
-                calendarEventSpec.location = intent.getStringExtra(EXTRA_CALENDAREVENT_LOCATION);
+                calendarEventSpec.title = sanitizeNotifText(intent.getStringExtra(EXTRA_CALENDAREVENT_TITLE));
+                calendarEventSpec.description = sanitizeNotifText(intent.getStringExtra(EXTRA_CALENDAREVENT_DESCRIPTION));
+                calendarEventSpec.location = sanitizeNotifText(intent.getStringExtra(EXTRA_CALENDAREVENT_LOCATION));
                 mDeviceSupport.onAddCalendarEvent(calendarEventSpec);
                 break;
             }
@@ -438,6 +455,7 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 setReceiversEnableState(false, false, null);
                 mGBDevice = null;
                 mDeviceSupport = null;
+                mCoordinator = null;
                 break;
             }
             case ACTION_FIND_DEVICE: {
@@ -454,7 +472,7 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 CallSpec callSpec = new CallSpec();
                 callSpec.command = intent.getIntExtra(EXTRA_CALL_COMMAND, CallSpec.CALL_UNDEFINED);
                 callSpec.number = intent.getStringExtra(EXTRA_CALL_PHONENUMBER);
-                callSpec.name = intent.getStringExtra(EXTRA_CALL_DISPLAYNAME);
+                callSpec.name = sanitizeNotifText(intent.getStringExtra(EXTRA_CALL_DISPLAYNAME));
                 mDeviceSupport.onSetCallState(callSpec);
                 break;
             case ACTION_SETCANNEDMESSAGES:
@@ -471,9 +489,9 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 break;
             case ACTION_SETMUSICINFO:
                 MusicSpec musicSpec = new MusicSpec();
-                musicSpec.artist = intent.getStringExtra(EXTRA_MUSIC_ARTIST);
-                musicSpec.album = intent.getStringExtra(EXTRA_MUSIC_ALBUM);
-                musicSpec.track = intent.getStringExtra(EXTRA_MUSIC_TRACK);
+                musicSpec.artist = sanitizeNotifText(intent.getStringExtra(EXTRA_MUSIC_ARTIST));
+                musicSpec.album = sanitizeNotifText(intent.getStringExtra(EXTRA_MUSIC_ALBUM));
+                musicSpec.track = sanitizeNotifText(intent.getStringExtra(EXTRA_MUSIC_TRACK));
                 musicSpec.duration = intent.getIntExtra(EXTRA_MUSIC_DURATION, 0);
                 musicSpec.trackCount = intent.getIntExtra(EXTRA_MUSIC_TRACKCOUNT, 0);
                 musicSpec.trackNr = intent.getIntExtra(EXTRA_MUSIC_TRACKNR, 0);
@@ -593,9 +611,11 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
             mDeviceSupport.dispose();
             mDeviceSupport = null;
             mGBDevice = null;
+            mCoordinator = null;
         }
         mDeviceSupport = deviceSupport;
         mGBDevice = mDeviceSupport != null ? mDeviceSupport.getDevice() : null;
+        mCoordinator = mGBDevice != null ? DeviceHelper.getInstance().getCoordinator(mGBDevice) : null;
     }
 
     private void start() {

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/amazfitbip/AmazfitBipSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/amazfitbip/AmazfitBipSupport.java
@@ -85,9 +85,9 @@ public class AmazfitBipSupport extends HuamiSupport {
             return;
         }
 
-        String senderOrTiltle = StringUtils.getFirstOf(notificationSpec.sender, notificationSpec.title);
+        String senderOrTitle = StringUtils.getFirstOf(notificationSpec.sender, notificationSpec.title);
 
-        String message = StringUtils.truncate(senderOrTiltle, 32) + "\0";
+        String message = StringUtils.truncate(senderOrTitle, 32) + "\0";
         if (notificationSpec.subject != null) {
             message += StringUtils.truncate(notificationSpec.subject, 128) + "\n\n";
         }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
@@ -20,7 +20,53 @@ package nodomain.freeyourgadget.gadgetbridge.util;
 import io.wax911.emojify.EmojiUtils;
 
 public class EmojiConverter {
+    private static final String[][] simpleEmojiMapping = {
+            {"\uD83D\uDE00", ":-D"},  // grinning
+            {"\uD83D\uDE01", ":-D"},  // grinning_face_with_smiling_eyes
+            {"\uD83D\uDE02", ":'D"},  // face_with_tears_of_joy
+            {"\uD83D\uDE03", ":-D"},  // smiling_face_with_open_mouth
+            {"\uD83D\uDE04", ":-D"},  // smiling_face_with_open_mouth_and_smiling_eyes
+            {"\uD83D\uDE05", ":'D"},  // smiling_face_with_open_mouth_and_cold_sweat
+            {"\uD83D\uDE06", "X-D"},  // smiling_face_with_open_mouth_and_tightly-closed_eyes
+            {"\uD83D\uDE07", "O:-)"}, // innocent
+            {"\uD83D\uDE09", ";-)"},  // wink
+            {"\uD83D\uDE0A", ":-)"},  // blush
+            {"\uD83D\uDE0B", ":-p"},  // yum
+            {"\uD83D\uDE0E", "B-)"},  // sunglasses
+            {"\uD83D\uDE15", ":-/"},  // confused
+            {"\uD83D\uDE16", ":-S"},  // confounded_face
+            {"\uD83D\uDE19", ":-*"},  // kissing_face_with_smiling_eyes
+            {"\uD83D\uDE17", ":*"},   // kissing_face
+            {"\uD83D\uDE1A", ":-*"},  // kissing_closed_eyes
+            {"\uD83D\uDE1B", ":-P"},  // stuck_out_tongue
+            {"\uD83D\uDE1C", ";-P"},  // stuck_out_tongue_winking_eye
+            {"\uD83D\uDE1D", "X-P"},  // stuck_out_tongue_and_tightly-closed_eyes
+            {"\uD83D\uDE1E", ":-S"},  // disappointed
+            {"\uD83D\uDE20", ":-@"},  // angry_face
+            {"\uD83D\uDE21", ":-@"},  // pouting_face
+            {"\uD83D\uDE22", ":'("},  // cry
+            {"\uD83D\uDE23", ":-("},  // preserving_face
+            {"\uD83D\uDE25", ":'("},  // disappointed_but_relieved_face
+            {"\uD83D\uDE2D", ":'("},  // loudly_crying_face
+            {"\uD83D\uDE2E", ":-O"},  // open_mouth
+            {"\uD83D\uDE32", "X-o"},  // astonished_face
+            {"\uD83D\uDE42", ":)"},   // slightly_smiling_face
+            {"\uD83D\uDE43", "(-:"},  // upside_down_face
+            {"\u2639", ":-("},        // frowning_face
+            {"\u2764", "<3"},         // heart
+    };
+
+    private static String convertSimpleEmojiToAscii(String text) {
+        for (String[] emojiMap : simpleEmojiMapping) {
+            text = text.replace(emojiMap[0], emojiMap[1]);
+        }
+        return text;
+    }
+
     public static String convertUnicodeEmojiToAscii(String text) {
+
+        text = convertSimpleEmojiToAscii(text);
+
         return EmojiUtils.shortCodify(text);
     }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
@@ -1,0 +1,26 @@
+/*  Copyright (C) 2018 Andreas Shimokawa, Matthieu Baerts
+
+    This file is part of Gadgetbridge.
+
+    Gadgetbridge is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Gadgetbridge is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package nodomain.freeyourgadget.gadgetbridge.util;
+
+import io.wax911.emojify.EmojiUtils;
+
+public class EmojiConverter {
+    public static String convertUnicodeEmojiToAscii(String text) {
+        return EmojiUtils.shortCodify(text);
+    }
+}


### PR DESCRIPTION
messages: convert emoji's to supported chars

Some devices don't support emoji's and display a series of `?` chars.
Instead of that, replace them by `:<emoji>:` text, e.g. `A 🐱` is
replaced by `A :cat:`.

This is done by using 'android-emojify' project and their
`EmojiUtils.shortCodify(text);` function.

For more details about this lib released under MIT license:

    https://anitrend.github.io/android-emojify/

Note that for the moment, only amazfitbip's devices have this feature
because I don't know if the other watches can display Emoji. Simply use
the function mentioned here above to add this feature for other devices.