### PR TITLE
Fix RTL test

### DIFF
--- a/app/src/test/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationServiceTestCase.java
+++ b/app/src/test/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationServiceTestCase.java
@@ -120,6 +120,7 @@ public class DeviceCommunicationServiceTestCase extends TestBase {
     public void testRtlSupport() {
         SharedPreferences settings = GBApplication.getPrefs().getPreferences();
         SharedPreferences.Editor editor = settings.edit();
+        editor.putBoolean("transliteration", false);
         editor.putBoolean(GBPrefs.RTL_SUPPORT, true);
         editor.commit();
 


### PR DESCRIPTION
Test _testRtlSupport_ in  _app/src/test/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationServiceTestCase.java_ fails

```
org.junit.ComparisonFailure: Rtl support fail! expected:<[תירבע English and]> but was:<[ English and
'bryth]>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at nodomain.freeyourgadget.gadgetbridge.service.DeviceCommunicationServiceTestCase.testRtlSupport(DeviceCommunicationServiceTestCase.java:130)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```
because expected string doesn't suppose that transliteration is performed. 

It's simply a side effect of the previous test _testTransliterationSupport_, that sets and tests transliteration.