### PR TITLE
Enable No1F1 support for a Chinese clone

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/no1f1/No1F1Coordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/no1f1/No1F1Coordinator.java
@@ -59,7 +59,7 @@ public class No1F1Coordinator extends AbstractDeviceCoordinator {
     @Override
     public DeviceType getSupportedType(GBDeviceCandidate candidate) {
         String name = candidate.getDevice().getName();
-        if (name != null && name.startsWith("X-RUN")) {
+        if (name != null && (name.startsWith("X-RUN") || name.startsWith("MH30"))) {
             return DeviceType.NO1F1;
         }
 


### PR DESCRIPTION
I bought a cheap Chinese-made dummy/smart-watch. It apparently uses the same chip/protocol as implemented in No1F1 device support, but it reports with a different name, so we need to add it to the hardcoded name-based detection.