### PR TITLE
emoji: do a lazy initialisation

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/GBApplication.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/GBApplication.java
@@ -53,7 +53,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import io.wax911.emojify.EmojiManager;
 import nodomain.freeyourgadget.gadgetbridge.database.DBHandler;
 import nodomain.freeyourgadget.gadgetbridge.database.DBHelper;
 import nodomain.freeyourgadget.gadgetbridge.database.DBOpenHelper;
@@ -198,8 +197,6 @@ public class GBApplication extends Application {
             }
             startService(new Intent(this, NotificationCollectorMonitorService.class));
         }
-
-        EmojiManager.initEmojiData(getApplicationContext());
     }
 
     @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
@@ -364,7 +364,7 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
             return text;
 
         if (!mCoordinator.supportsUnicodeEmojis())
-            return EmojiConverter.convertUnicodeEmojiToAscii(text);
+            return EmojiConverter.convertUnicodeEmojiToAscii(text, getApplicationContext());
 
         return text;
     }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
@@ -17,6 +17,9 @@
 
 package nodomain.freeyourgadget.gadgetbridge.util;
 
+import android.content.Context;
+
+import io.wax911.emojify.EmojiManager;
 import io.wax911.emojify.EmojiUtils;
 
 public class EmojiConverter {
@@ -56,6 +59,8 @@ public class EmojiConverter {
             {"\u2764", "<3"},         // heart
     };
 
+    private static boolean isInitialised = false;
+
     private static String convertSimpleEmojiToAscii(String text) {
         for (String[] emojiMap : simpleEmojiMapping) {
             text = text.replace(emojiMap[0], emojiMap[1]);
@@ -63,10 +68,21 @@ public class EmojiConverter {
         return text;
     }
 
-    public static String convertUnicodeEmojiToAscii(String text) {
-
-        text = convertSimpleEmojiToAscii(text);
+    private static String convertAdvancedEmojiToAscii(String text, Context context) {
+        // Do a lazy initialisation not to slowdown the startup and when it is needed
+        if (!isInitialised) {
+            EmojiManager.initEmojiData(context);
+            isInitialised = true;
+        }
 
         return EmojiUtils.shortCodify(text);
+    }
+
+    public static String convertUnicodeEmojiToAscii(String text, Context context) {
+        text = convertSimpleEmojiToAscii(text);
+
+        text = convertAdvancedEmojiToAscii(text, context);
+
+        return text;
     }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
@@ -23,6 +23,7 @@ import io.wax911.emojify.EmojiManager;
 import io.wax911.emojify.EmojiUtils;
 
 public class EmojiConverter {
+
     private static final String[][] simpleEmojiMapping = {
             {"\uD83D\uDE00", ":-D"},  // grinning
             {"\uD83D\uDE01", ":-D"},  // grinning_face_with_smiling_eyes
@@ -38,8 +39,9 @@ public class EmojiConverter {
             {"\uD83D\uDE0E", "B-)"},  // sunglasses
             {"\uD83D\uDE15", ":-/"},  // confused
             {"\uD83D\uDE16", ":-S"},  // confounded_face
-            {"\uD83D\uDE19", ":-*"},  // kissing_face_with_smiling_eyes
             {"\uD83D\uDE17", ":*"},   // kissing_face
+            {"\uD83D\uDE18", ";-*"},  // face_throwing_a_kiss
+            {"\uD83D\uDE19", ":-*"},  // kissing_face_with_smiling_eyes
             {"\uD83D\uDE1A", ":-*"},  // kissing_closed_eyes
             {"\uD83D\uDE1B", ":-P"},  // stuck_out_tongue
             {"\uD83D\uDE1C", ";-P"},  // stuck_out_tongue_winking_eye


### PR DESCRIPTION
The goal is not to slowdown the startup but also to do this initialisation only when it is needed.

Suggested-by: @cpfeiffer 

Note for @cpfeiffer : in your suggestion, you said:

> I would like to see this be done on demand, e.g. in `sanitizeNotifText()`

I moved this to the new EmojiConverter class to do everything related to the emoji there. I hope it  is OK for you :)