### PR TITLE
Added Foreground Service permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.MEDIA_CONTENT_CONTROL" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-permission android:name="cyanogenmod.permission.ACCESS_WEATHER_MANAGER" />
     <uses-permission android:name="cyanogenmod.permission.READ_WEATHER" />


### PR DESCRIPTION
[This permission](https://developer.android.com/reference/android/Manifest.permission#FOREGROUND_SERVICE) [will be required](https://developer.android.com/about/versions/pie/android-9.0-migration#tya) if targetSDK is bumped, it doesn't hurt to make this change preemptively.