### PR TITLE
Added a try-catch to not crash on de-emojifying

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/EmojiConverter.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2018 Andreas Shimokawa, Matthieu Baerts
+/*  Copyright (C) 2019 Andreas Shimokawa, Matthieu Baerts, Taavi Eomäe
 
     This file is part of Gadgetbridge.
 
@@ -19,10 +19,14 @@ package nodomain.freeyourgadget.gadgetbridge.util;
 
 import android.content.Context;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.wax911.emojify.EmojiManager;
 import io.wax911.emojify.EmojiUtils;
 
 public class EmojiConverter {
+    private static final Logger LOG = LoggerFactory.getLogger(EmojiConverter.class);
 
     private static final String[][] simpleEmojiMapping = {
             {"\uD83D\uDE00", ":-D"},  // grinning
@@ -80,8 +84,12 @@ public class EmojiConverter {
 
     private static String convertAdvancedEmojiToAscii(String text, Context context) {
         initEmojiData(context);
-
-        return EmojiUtils.shortCodify(text);
+        try {
+            return EmojiUtils.shortCodify(text);
+        } catch (Exception e){
+            LOG.warn("An exception occured when converting advanced emoji to ASCII", text);
+            return text;
+        }
     }
 
     public static String convertUnicodeEmojiToAscii(String text, Context context) {


### PR DESCRIPTION
This fixes the crashing on de-emojifying due to some unknown null. I think it's better at the moment to display `[?]` than to crash. I also added logging to the class to store strings that would otherwise crash the app in the logs.

```
Caused by: java.lang.NullPointerException: 
  at io.wax911.emojify.EmojiUtils.shortCodify (EmojiUtils.java:222)
  at ee.aegrel.gadgetbridge.util.EmojiConverter.convertAdvancedEmojiToAscii (EmojiConverter.java:84)
  at ee.aegrel.gadgetbridge.util.EmojiConverter.convertUnicodeEmojiToAscii (EmojiConverter.java:90)
  at ee.aegrel.gadgetbridge.service.DeviceCommunicationService.sanitizeNotifText (DeviceCommunicationService.java:367)
  at ee.aegrel.gadgetbridge.service.DeviceCommunicationService.handleAction (DeviceCommunicationService.java:383)
  at ee.aegrel.gadgetbridge.service.DeviceCommunicationService.onStartCommand (DeviceCommunicationService.java:351)
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:2924)
  at android.app.ActivityThread.access$2100 (ActivityThread.java:155)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1415)
  at android.os.Handler.dispatchMessage (Handler.java:102)
  at android.os.Looper.loop (Looper.java:135)
  at android.app.ActivityThread.main (ActivityThread.java:5343)
  at java.lang.reflect.Method.invoke (Method.java)
  at java.lang.reflect.Method.invoke (Method.java:372)
  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:907)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:702)
```