### PR TITLE
Adding functionality for an additional "disconnected" accent.

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GB.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/GB.java
@@ -98,7 +98,7 @@ public class GB {
                 .setContentText(text)
                 .setSmallIcon(connected ? R.drawable.ic_notification : R.drawable.ic_notification_disconnected)
                 .setContentIntent(getContentIntent(context))
-                .setColor(context.getResources().getColor(R.color.accent))
+                .setColor(context.getResources().getColor(connected ? R.color.accent : R.color.accent_disconnected))
                 .setOngoing(true);
 
         Intent deviceCommunicationServiceIntent = new Intent(context, DeviceCommunicationService.class);
@@ -132,7 +132,7 @@ public class GB {
                 .setContentText(text)
                 .setSmallIcon(R.drawable.ic_notification_disconnected)
                 .setContentIntent(getContentIntent(context))
-                .setColor(context.getResources().getColor(R.color.accent))
+                .setColor(context.getResources().getColor(R.color.accent_disconnected))
                 .setOngoing(true);
         if (GBApplication.getPrefs().getString("last_device_address", null) != null) {
             Intent deviceCommunicationServiceIntent = new Intent(context, DeviceCommunicationService.class);

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="primarydark_dark" type="color">#dd2c00</color>
 
     <color name="accent" type="color">#0091ea</color>
+    <color name="accent_disconnected" type="color">#ea0000</color>
 
     <color name="primarytext_light" type="color">#000000</color>
     <color name="primarytext_dark" type="color">#ffffff</color>


### PR DESCRIPTION
A simple change that changes the color of the app notification when the watch is disconnected. I kept having some disconnects and not realizing that it hadn't been syncing data for quite a while. I believe this will help address that.

Thanks,
Lucas