### PR TITLE
Initial implementation for Mi Band 2 'custom menu'

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandConst.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/miband/MiBandConst.java
@@ -32,6 +32,8 @@ public final class MiBandConst {
     public static final String PREF_MIBAND_ALARMS = "mi_alarms";
     public static final String PREF_MIBAND_DONT_ACK_TRANSFER = "mi_dont_ack_transfer";
     public static final String PREF_MIBAND_RESERVE_ALARM_FOR_CALENDAR = "mi_reserve_alarm_calendar";
+    public static final String PREF_MIBAND_BUTTON_ACTION_MENU_ENABLE = "mi2_enable_button_action_menu";
+    public static final String PREF_MIBAND_MENU_ELEMENTS = "mi2_menu_elements";
     public static final String PREF_MIBAND_BUTTON_ACTION_ENABLE = "mi2_enable_button_action";
     public static final String PREF_MIBAND_BUTTON_ACTION_VIBRATE = "mi2_button_action_vibrate";
     public static final String PREF_MIBAND_BUTTON_PRESS_COUNT = "mi_button_press_count";

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/miband2/Mi2CustomMenuNotificationStrategy.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/miband2/Mi2CustomMenuNotificationStrategy.java
@@ -1,0 +1,60 @@
+/*  Copyright (C) 2017-2019 Andreas Shimokawa, Carsten Pfeiffer, Daniele
+    Gobbetti
+
+    This file is part of Gadgetbridge.
+
+    Gadgetbridge is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Gadgetbridge is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+package nodomain.freeyourgadget.gadgetbridge.service.devices.huami.miband2;
+
+import android.bluetooth.BluetoothGattCharacteristic;
+
+import androidx.annotation.NonNull;
+import nodomain.freeyourgadget.gadgetbridge.devices.miband.VibrationProfile;
+import nodomain.freeyourgadget.gadgetbridge.service.btle.BLETypeConversions;
+import nodomain.freeyourgadget.gadgetbridge.service.btle.BtLEAction;
+import nodomain.freeyourgadget.gadgetbridge.service.btle.GattCharacteristic;
+import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
+import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.alertnotification.AlertCategory;
+import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.alertnotification.AlertNotificationProfile;
+import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.alertnotification.NewAlert;
+import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.alertnotification.OverflowStrategy;
+import nodomain.freeyourgadget.gadgetbridge.service.devices.common.SimpleNotification;
+import nodomain.freeyourgadget.gadgetbridge.service.devices.huami.HuamiIcon;
+import nodomain.freeyourgadget.gadgetbridge.service.devices.huami.HuamiSupport;
+import nodomain.freeyourgadget.gadgetbridge.util.StringUtils;
+
+public class Mi2CustomMenuNotificationStrategy extends Mi2NotificationStrategy {
+    public Mi2CustomMenuNotificationStrategy(HuamiSupport support) {
+        super(support);
+    }
+
+    @Override
+    protected void sendCustomNotification(VibrationProfile vibrationProfile, SimpleNotification simpleNotification, BtLEAction extraAction, TransactionBuilder builder) {
+        // announce text messages with configured alerts first
+        // TODO this seems non-necessary
+        //super.sendCustomNotification(vibrationProfile, simpleNotification, extraAction, builder);
+        // and finally send the text message, if any
+        if (simpleNotification != null && !StringUtils.isEmpty(simpleNotification.getMessage())) {
+            sendAlert(simpleNotification, builder);
+        }
+    }
+
+    protected void sendAlert(@NonNull SimpleNotification simpleNotification, TransactionBuilder builder) {
+        AlertNotificationProfile<?> profile = new AlertNotificationProfile<>(getSupport());
+        // override the alert category,  since only SMS and incoming call support text notification
+        AlertCategory category = AlertCategory.SMS;
+        NewAlert alert = new NewAlert(category, 1, simpleNotification.getMessage());
+        profile.newAlert(builder, alert, OverflowStrategy.MAKE_MULTIPLE);
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -435,6 +435,10 @@
     <string name="prefs_disconnect_notification">Disconnect notification</string>
     <string name="mi2_prefs_button_actions">Button actions</string>
     <string name="mi2_prefs_button_actions_summary">Specify actions on Mi Band 2 button press</string>
+    <string name="mi2_prefs_button_action_menu">Custom Menu</string>
+    <string name="mi2_prefs_button_action_menu_summary">Create a custom menu on Mi Band 2</string>
+    <string name="mi2_prefs_menu_elements">Menu Elements</string>
+    <string name="mi2_prefs_menu_elements_summary">The elements of your menu (label1:message1;label2:message2;...)</string>
     <string name="mi2_prefs_button_press_count">Button press count</string>
     <string name="mi2_prefs_button_press_count_summary">Number of button presses to trigger message broadcast</string>
     <string name="mi2_prefs_button_press_broadcast">Broadcast message to send</string>

--- a/app/src/main/res/xml/miband_preferences.xml
+++ b/app/src/main/res/xml/miband_preferences.xml
@@ -84,6 +84,32 @@
                 android:key="mi_button_press_count_match_delay"
                 android:summary="@string/mi2_prefs_button_press_count_match_delay_summary"
                 android:title="@string/mi2_prefs_button_press_count_match_delay" />
+
+            <PreferenceScreen
+                android:key="mi2_button_action_menu_key"
+                android:summary="@string/mi2_prefs_button_action_menu_summary"
+                android:title="@string/mi2_prefs_button_action_menu"
+                android:persistent="false">
+
+                <!-- workaround for missing toolbar -->
+                <PreferenceCategory
+                    android:title="@string/mi2_prefs_button_action_menu"
+                    />
+          
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="mi2_enable_button_action_menu"
+                    android:summary="@string/mi2_prefs_button_action_menu_summary"
+                    android:title="@string/mi2_prefs_button_action_menu" />
+          
+                <EditTextPreference
+                    android:defaultValue="Menu1:ee.aegrel.gadgetbridge.mibandMenu1Selected"
+                    android:dependency="mi2_enable_button_action_menu"
+                    android:key="mi2_menu_elements"
+                    android:summary="@string/mi2_prefs_menu_elements_summary"
+                    android:title="@string/mi2_prefs_menu_elements" />
+
+            </PreferenceScreen>
         </PreferenceScreen>
 
         <EditTextPreference


### PR DESCRIPTION
Hi,

First of all, thanks for this great app.

This PR implements a "custom menu" feature using the func button of the Mi Band 2. Something very similar to what is shown in [this YouTube video](https://www.youtube.com/watch?v=i9QoAukmoGs).

Here are the needed configuration steps : 
- Enable the Mi Band Action button
- Set a minimum value for "Delay Button After Action" (otherwise, the first menu option may not display correctly on the band).
- Enable the Custom Menu under "Button Action" > "Custom Menu" and set the "Menu Elements" (that's very gross for now...you have to input it as `Label1:Message1;Label2:Message2;...`).
- Enable Text notifications in Mi Band 2 specific settings
- You're good to go : now, the "Button Action" will trigger the custom menu opening. Then, single tap to move forward in the menu, double tap to move backwards, and triple tap to validate (so it will broadcast the associated message, which you can catch in any automation tool). If you don't do anything during 5 secs, the menu will close.

It's working great but : 
- The band vibrates every time it gets a "menu notification", i'm not sure why, and i couldn't find a way to get around.
- I have no idea if this PR may or may not have impact on other existing devices support. It should not, but you never know. I hope i'm not adding more spaghettis :-).

Some improveable-s :
- Custom separators / better UI for the "Menu Elements" string
- Custom controls for the menu (easy one, but i don't have much time this week).

Thanks in adv. for your feedback.