### PR TITLE
Add pebblekit extension for reopening last app

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleActiveAppTracker.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleActiveAppTracker.java
@@ -1,0 +1,40 @@
+package nodomain.freeyourgadget.gadgetbridge.service.devices.pebble;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.UUID;
+
+public class PebbleActiveAppTracker {
+    private @Nullable UUID mPreviousRunningApp = null;
+    private @Nullable UUID mCurrentRunningApp = null;
+
+    @Nullable
+    public UUID getPreviousRunningApp() {
+        return mPreviousRunningApp;
+    }
+
+    @Nullable
+    public UUID getCurrentRunningApp() {
+        return mCurrentRunningApp;
+    }
+
+    public void markAppClosed(@NonNull UUID app) {
+        if (mCurrentRunningApp == app) {
+            if (mPreviousRunningApp != null) {
+                markAppOpened(mPreviousRunningApp);
+            } else {
+                mCurrentRunningApp = null;
+            }
+        }
+    }
+
+    public void markAppOpened(@NonNull UUID openedApp) {
+        if (openedApp.equals(mCurrentRunningApp)) {
+            return;
+        }
+
+        mPreviousRunningApp = mCurrentRunningApp;
+        mCurrentRunningApp = openedApp;
+    }
+}

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleKitSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleKitSupport.java
@@ -44,6 +44,8 @@ class PebbleKitSupport {
     private static final String PEBBLEKIT_ACTION_APP_START = "com.getpebble.action.app.START";
     private static final String PEBBLEKIT_ACTION_APP_STOP = "com.getpebble.action.app.STOP";
 
+    private static final String PEBBLEKIT_EXTRA_REOPEN_LAST_APP = "com.getpebble.action.app.REOPEN_LAST_APP";
+
     private static final String PEBBLEKIT_ACTION_DL_RECEIVE_DATA_NEW = "com.getpebble.action.dl.RECEIVE_DATA_NEW";
     //private static final String PEBBLEKIT_ACTION_DL_RECEIVE_DATA = "com.getpebble.action.dl.RECEIVE_DATA";
     private static final String PEBBLEKIT_ACTION_DL_ACK_DATA = "com.getpebble.action.dl.ACK_DATA";
@@ -73,7 +75,12 @@ class PebbleKitSupport {
                 case PEBBLEKIT_ACTION_APP_STOP:
                     uuid = (UUID) intent.getSerializableExtra("uuid");
                     if (uuid != null) {
-                        mPebbleIoThread.write(mPebbleProtocol.encodeAppStart(uuid, action.equals(PEBBLEKIT_ACTION_APP_START)));
+                        if (action.equals(PEBBLEKIT_ACTION_APP_STOP) &&
+                                intent.getBooleanExtra(PEBBLEKIT_EXTRA_REOPEN_LAST_APP, false)) {
+                            mPebbleIoThread.reopenLastApp(uuid);
+                        } else {
+                            mPebbleIoThread.write(mPebbleProtocol.encodeAppStart(uuid, action.equals(PEBBLEKIT_ACTION_APP_START)));
+                        }
                     }
                     break;
                 case PEBBLEKIT_ACTION_APP_SEND:

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/pebble/PebbleProtocol.java
@@ -2156,7 +2156,12 @@ public class PebbleProtocol extends GBDeviceProtocol {
                 break;
             case APPRUNSTATE_STOP:
                 LOG.info(ENDPOINT_NAME + ": stopped " + uuid);
-                break;
+
+                GBDeviceEventAppManagement gbDeviceEventAppManagement = new GBDeviceEventAppManagement();
+                gbDeviceEventAppManagement.uuid = uuid;
+                gbDeviceEventAppManagement.type = GBDeviceEventAppManagement.EventType.STOP;
+                gbDeviceEventAppManagement.event = GBDeviceEventAppManagement.Event.SUCCESS;
+                return new GBDeviceEvent[]{gbDeviceEventAppManagement};
             default:
                 LOG.info(ENDPOINT_NAME + ": (cmd:" + command + ")" + uuid);
                 break;


### PR DESCRIPTION
There are several 3rd party Pebble apps that open up momentarily via PebbleKit (for example to pop up alert or notification). Those app start themselves via PebbleKit start and stop intents.

However, there is slight usability issue with those: If you have anything else open on the watch other than watchface (for example a running timer or sports tracker) when momentary app opens, previous app will be closed and after new app is finished, watch will return to the watchface. That can be annoying to the user.

With official Pebble app, this problem was solved by hooking into developer connection service and sniffing packets from there. It was very hacky and insecure. With Gadgetbridge, there is no developer connection, but since this app is open source, I figure I could add extension to the PebbleKit interface that would enable this functionality in much saner way.

PR adds `com.getpebble.action.app.REOPEN_LAST_APP` extra to the `com.getpebble.action.app.STOP` PebbleKit intent. If extra is true, app will be replaced by previously running app instead of watchface.