### PR TITLE
Amazfit Bip: Add new latin languages

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/amazfitbip/AmazfitBipSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/amazfitbip/AmazfitBipSupport.java
@@ -515,6 +515,22 @@ public class AmazfitBipSupport extends HuamiSupport {
                 command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
                 localeString = "ru_RU";
                 break;
+            case 5:
+                command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
+                localeString = "de_DE";
+                break;
+            case 6:
+                command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
+                localeString = "it_IT";
+                break;
+            case 7:
+                command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
+                localeString = "fr_FR";
+                break;
+            case 8:
+                command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
+                localeString = "tr_TR";
+                break;
             default:
                 switch (language) {
                     case "zh":
@@ -533,6 +549,22 @@ public class AmazfitBipSupport extends HuamiSupport {
                     case "ru":
                         command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
                         localeString = "ru_RU";
+                        break;
+                    case "de":
+                        command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
+                        localeString = "de_DE";
+                        break;
+                    case "it":
+                        command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
+                        localeString = "it_IT";
+                        break;
+                    case "fr":
+                        command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
+                        localeString = "fr_FR";
+                        break;
+                    case "tr":
+                        command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;
+                        localeString = "tr_TR";
                         break;
                     default:
                         command_old = AmazfitBipService.COMMAND_SET_LANGUAGE_ENGLISH;

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -356,6 +356,10 @@
         <item name="2">@string/english</item>
         <item name="3">@string/spanish</item>
         <item name="4">@string/russian</item>
+        <item name="5">@string/german</item>
+        <item name="6">@string/italian</item>
+        <item name="7">@string/french</item>
+        <item name="8">@string/turkish</item>
     </string-array>
 
     <string-array name="pref_amazfitbip_language_values">
@@ -365,6 +369,10 @@
         <item>2</item>
         <item>3</item>
         <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
     </string-array>
 
     <string-array name="pref_miband3_language">


### PR DESCRIPTION
Since Latin firmware 1.1.5.36 there are additional languages available:
- German
- Italian
- French
- Turkish

I tested switching between them without any problems.