### PR TITLE
Add support for ignoring (muting) calls

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/deviceevents/GBDeviceEventCallControl.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/deviceevents/GBDeviceEventCallControl.java
@@ -28,5 +28,6 @@ public class GBDeviceEventCallControl extends GBDeviceEvent {
         OUTGOING,
         REJECT,
         START,
+        IGNORE,
     }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/AbstractDeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/AbstractDeviceSupport.java
@@ -198,6 +198,13 @@ public abstract class AbstractDeviceSupport implements DeviceSupport {
     private void handleGBDeviceEvent(GBDeviceEventCallControl callEvent) {
         Context context = getContext();
         LOG.info("Got event for CALL_CONTROL");
+        if(callEvent.event == GBDeviceEventCallControl.Event.IGNORE) {
+            LOG.info("Sending intent for mute");
+            Intent broadcastIntent = new Intent("nodomain.freeyourgadget.gadgetbridge.MUTE_CALL");
+            broadcastIntent.setPackage(context.getPackageName());
+            context.sendBroadcast(broadcastIntent);
+            return;
+        }
         Intent callIntent = new Intent(GBCallControlReceiver.ACTION_CALLCONTROL);
         callIntent.putExtra("event", callEvent.event.ordinal());
         callIntent.setPackage(context.getPackageName());

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/DeviceCommunicationService.java
@@ -686,6 +686,7 @@ public class DeviceCommunicationService extends Service implements SharedPrefere
                 IntentFilter filter = new IntentFilter();
                 filter.addAction("android.intent.action.PHONE_STATE");
                 filter.addAction("android.intent.action.NEW_OUTGOING_CALL");
+                filter.addAction("nodomain.freeyourgadget.gadgetbridge.MUTE_CALL");
                 registerReceiver(mPhoneCallReceiver, filter);
             }
             if (mSMSReceiver == null) {

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/casiogb6900/CasioGB6900DeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/casiogb6900/CasioGB6900DeviceSupport.java
@@ -35,6 +35,7 @@ import java.util.Calendar;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventCallControl;
 import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventFindPhone;
 import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventMusicControl;
 import nodomain.freeyourgadget.gadgetbridge.devices.casiogb6900.CasioGB6900Constants;
@@ -437,7 +438,9 @@ public class CasioGB6900DeviceSupport extends AbstractBTLEDeviceSupport {
         if(characteristicUUID.equals(CasioGB6900Constants.RINGER_CONTROL_POINT)) {
             if(data[0] == 0x02)
             {
-                LOG.info("Mute/ignore call event not yet supported by GB");
+                GBDeviceEventCallControl callControlEvent = new GBDeviceEventCallControl();
+                callControlEvent.event = GBDeviceEventCallControl.Event.IGNORE;
+                evaluateGBDeviceEvent(callControlEvent);
             }
             handled = true;
         }


### PR DESCRIPTION
Muting an incoming call is an important feature for me which, unfortunately, Gadgetbridge is lacking. This PR adds support for it by temporarily changing the ringerMode to silent and restoring it back once the call has finished.

Although there are "silenceRinger" methods in ITelephony and TelecomManager, they are only available to system applications. Hence, the workaround is necessary.

The Casio implementation has been updated to add support for ignoring calls.