### PR TITLE
Add catalan language

### DIFF
--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1,99 +1,86 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<resources><string name="app_name">Gadgetbridge</string>
-
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Gadgetbridge</string>
     <string name="title_activity_controlcenter">Gadgetbridge</string>
-    <string name="action_settings">Paràmetres</string>
+    <string name="action_settings">Configuració</string>
     <string name="action_debug">Depuració</string>
-    <string name="action_quit">Sortir</string>
+    <string name="action_quit">Surt</string>
     <string name="action_donate">Donació</string>
     <string name="controlcenter_fetch_activity_data">Sincronitza</string>
     <string name="controlcenter_start_sleepmonitor">Seguiment del son (ALPHA)</string>
-    <string name="controlcenter_find_device">Cercar dispositiu perdut</string>
-    <string name="controlcenter_take_screenshot">Fer captura de pantalla</string>
-    <string name="controlcenter_connect">Connectar</string>
+    <string name="controlcenter_find_device">Cerca un dispositiu perdut</string>
+    <string name="controlcenter_take_screenshot">Fes una captura de pantalla</string>
+    <string name="controlcenter_connect">Connecta…</string>
     <string name="controlcenter_disconnect">Desconnecta</string>
-    <string name="controlcenter_delete_device">Esborra dispositiu</string>
-    <string name="controlcenter_delete_device_name">Esborrar %1$s</string>
-    <string name="controlcenter_delete_device_dialogmessage">Aquesta acció esborrarà el dispositiu i tota la seva informació associada!</string>
-    <string name="controlcenter_navigation_drawer_open">Obrir el calaix de navegació</string>
-    <string name="controlcenter_navigation_drawer_close">Tancar el calaix de navegació</string>
-    <string name="controlcenter_snackbar_need_longpress">Mantenir premut la icona per desconnecta</string>
-    <string name="controlcenter_snackbar_disconnecting">Desconnectant</string>
-    <string name="controlcenter_snackbar_connecting">Connectant</string>
-    <string name="controlcenter_snackbar_requested_screenshot">Fer captura de pantalla del dispositiu</string>
-
-
+    <string name="controlcenter_delete_device">Esborra l\'aparell</string>
+    <string name="controlcenter_delete_device_name">Esborra %1$s</string>
+    <string name="controlcenter_delete_device_dialogmessage">Aquesta acció esborrarà l\'aparell i tota la seva informació associada!</string>
+    <string name="controlcenter_navigation_drawer_open">Obre el calaix de navegació</string>
+    <string name="controlcenter_navigation_drawer_close">Tanca el calaix de navegació</string>
+    <string name="controlcenter_snackbar_need_longpress">Mantingueu premut l\'element per desconnectar</string>
+    <string name="controlcenter_snackbar_disconnecting">S\'està desconnectant</string>
+    <string name="controlcenter_snackbar_connecting">S\'està connectant…</string>
+    <string name="controlcenter_snackbar_requested_screenshot">S\'està fent una captura de pantalla de l\'aparell</string>
     <string name="title_activity_debug">Depuració</string>
-
-    <string name="title_activity_appmanager">Gestor de l\'aplicació</string>
-    <string name="appmanager_cached_watchapps_watchfaces">Aplicació en memòria cau</string>
+    <string name="title_activity_appmanager">Gestor d\'aplicacions</string>
+    <string name="appmanager_cached_watchapps_watchfaces">Aplicacions a la memòria cau</string>
     <string name="appmanager_installed_watchapps">Aplicacions instal·lades</string>
-    <string name="appmanager_installed_watchfaces">Esferes instal·lades</string>
-    <string name="appmananger_app_delete">Esborrar</string>
-    <string name="appmananger_app_delete_cache">Esborra i treu de la memòria cau</string>
-    <string name="appmananger_app_reinstall">Reinstal·lar</string>
-    <string name="appmanager_app_openinstore">Cerca a Pebble Appstore</string>
-    <string name="appmanager_health_activate">Activar</string>
-    <string name="appmanager_health_deactivate">Desactivar</string>
-    <string name="appmanager_hrm_activate">Activar seguiment d\'activitat cardíaca</string>
-    <string name="appmanager_hrm_deactivate">Desactivar seguiment d\'activitat cardíaca</string>
-    <string name="appmanager_weather_activate">Activar l\'aplicació del temps del sistema</string>
-    <string name="appmanager_weather_deactivate">Desactivar l\'aplicació del temps del sistema</string>
-    <string name="appmanager_weather_install_provider">Instal·lar l\'aplicació del temps del sistema</string>
-    <string name="app_configure">Configurar</string>
-    <string name="app_move_to_top">Moure a la part superior</string>
-
-    <string name="title_activity_appblacklist">Llista negra de notificacions</string>
-
-    <string name="title_activity_calblacklist">Calendaris en llista negra</string>
-
-    <string name="title_activity_fw_app_insaller">Instal·lador de FW/App</string>
-    <string name="fw_upgrade_notice">Estàs a punt d\'instal·lar el firmware %s en lloc del que està a la teva MiBand.</string>
-    <string name="fw_upgrade_notice_amazfitbip">Esteu a punt d\'instal·lar el firmware %s en el vostre Amazfit Bip. 
+    <string name="appmanager_installed_watchfaces">Caràtules instal·lades</string>
+    <string name="appmananger_app_delete">Esborra</string>
+    <string name="appmananger_app_delete_cache">Esborra i suprimeix de la memòria cau</string>
+    <string name="appmananger_app_reinstall">Reinstal·la</string>
+    <string name="appmanager_app_openinstore">Cerca a la botiga d\'aplicacions de Pebble</string>
+    <string name="appmanager_health_activate">Activa</string>
+    <string name="appmanager_health_deactivate">Desactiva</string>
+    <string name="appmanager_hrm_activate">Activa el seguiment de ritme cardíac</string>
+    <string name="appmanager_hrm_deactivate">Desactiva el seguiment de ritme cardíac</string>
+    <string name="appmanager_weather_activate">Activa l\'aplicació del temps del sistema</string>
+    <string name="appmanager_weather_deactivate">Desactiva l\'aplicació del temps del sistema</string>
+    <string name="appmanager_weather_install_provider">Instal·la l\'aplicació del temps del sistema</string>
+    <string name="app_configure">Configura</string>
+    <string name="app_move_to_top">Mou a la part superior</string>
+    <string name="title_activity_appblacklist">Bloqueig de notificacions</string>
+    <string name="title_activity_calblacklist">Calendaris bloquejats</string>
+    <string name="title_activity_fw_app_insaller">Instal·lador de microprogramari i aplicacions</string>
+    <string name="fw_upgrade_notice">Sou a punt d\'instal·lar el %s.</string>
+    <string name="fw_upgrade_notice_amazfitbip">Esteu a punt d\'instal·lar el microprogramari %s en el vostre Amazfit Bip. 
 \n 
 \nSi us plau, assegure-vos d\'instal·lar el fitxer .fw, el fitxer .res i, finalment, el fitxer .gps. El vostre rellotge reiniciarà després d\'instal·lar l\'arxiu .fw. 
 \n 
-\nNota: no heu d\'instal·lar .res i .gps si aquests fitxers són els mateixos que els prèviament instal·lats. 
+\nNota: no heu d\'instal·lar els fitxers .res i .gps si aquests fitxers són exactament els mateixos que els prèviament instal·lats. 
 \n 
 \nPROCEDIU SOTA LA VOSTRA PRÒPIA RESPONSABILITAT!</string>
-    <string name="fw_upgrade_notice_amazfitcor">Esteu a punt d\'instal·lar el firmware %s en el vostre Amazfit Cor.
-\n
-\nSi us plau, assegure-vos d\'instal·lar el fitxer .fw i el fitxer .res. El vostre rellotge reiniciarà després d\'instal·lar l\'arxiu .fw.
-\n
-\nNota: no heu d\'instal·lar .res si aquest fitxer és el mateix que el prèviament instal·lat.
-\n
-\nNO TESTAT. POT ESTAVELLAR EL VOSTRE DISPOSITIU. PROCEDIU SOTA LA VOSTRA PRÒPIA RESPONSABILITAT!</string>
-    <string name="fw_multi_upgrade_notice">Estàs a punt d\'instal·lar els firmwares %1$s i %2$s en lloc dels de la vostra MiBand.</string>
-    <string name="miband_firmware_known">Aquest firmware ha estat provat i se sap que és compatible amb Gadgetbridge.</string>
-    <string name="miband_firmware_unknown_warning">Aquest firmware no ha estat provat i pot ser que no sigui compatible amb Gadgetbridge.
-\n
-\nNO es recomana la instal·lació en el teu MiBand!</string>
-    <string name="miband_firmware_suggest_whitelist">Si tot i així vols seguir i les coses continuen funcionant correctament, si us plau indica\'ls als desenvolupadors de Gadgetbridge que aquesta versió del firmware funciona bé: %s</string>
-
-    <string name="title_activity_settings">Paràmetres</string>
-
-    <string name="pref_header_general">Paràmetres generals</string>
-    <string name="pref_title_general_autoconnectonbluetooth">Connectar-se al dispositiu quan el Bluetooth estigui activat</string>
+    <string name="fw_upgrade_notice_amazfitcor">Sou a punt d\'instal·lar el microprogramari %s en el vostre Amazfit Cor. 
+\n 
+\nSi us plau, assegure-vos d\'instal·lar el fitxer .fw i el fitxer .res. La vostra polsera reiniciarà després d\'instal·lar l\'arxiu .fw. 
+\n 
+\nNota: no heu d\'instal·lar el fitxer .res si és exactament el mateix que el prèviament instal·lat. 
+\n 
+\nPROCEDIU SOTA LA VOSTRA PRÒPIA RESPONSABILITAT!</string>
+    <string name="fw_multi_upgrade_notice">"Sou a punt d\'instal·lar els microprogramaris  %1$s i %2$s en lloc dels que hi ha actualment a la vostra Mi Band."</string>
+    <string name="miband_firmware_known">Aquest microprogramari ha estat provat i se sap que és compatible amb el Gadgetbridge.</string>
+    <string name="miband_firmware_unknown_warning">Aquest microprogramari no ha estat provat i pot ser que no sigui compatible amb el Gadgetbridge. 
+\n 
+\nNO es recomana instal·lar-lo!</string>
+    <string name="miband_firmware_suggest_whitelist">Si tot i així voleu continuar i les coses continuen funcionant correctament, si us plau informeu els desenvolupadors del Gadgetbridge que la versió %s del microprogramari funciona bé.</string>
+    <string name="title_activity_settings">Configuració</string>
+    <string name="pref_header_general">Configuració general</string>
+    <string name="pref_title_general_autoconnectonbluetooth">Connecta\'t a l\'aparell Gadgetbridge quan el Bluetooth estigui activat</string>
     <string name="pref_title_general_autostartonboot">Inicia automàticament</string>
     <string name="pref_title_general_autoreconnect">Reconnecta automàticament</string>
-    <string name="pref_title_audio_player">Reproductor preferit</string>
+    <string name="pref_title_audio_player">Reproductor d\'àudio preferit</string>
     <string name="pref_default">Per defecte</string>
-    <string name="pref_title_charts_swipe">Permetre lliscar cap a l\'esquerra/dreta en els gràfics d\'activitat</string>
-
+    <string name="pref_title_charts_swipe">Permet lliscar cap a l\'esquerra i la dreta en els gràfics d\'activitat</string>
     <string name="pref_header_datetime">Data i Hora</string>
     <string name="pref_title_datetime_syctimeonconnect">Sincronitza l\'hora</string>
-    <string name="pref_summary_datetime_syctimeonconnect">Sincronitza l\'hora en el dispositiu quan es connecti o es canviï l\'hora o zona horària en Android</string>
-
+    <string name="pref_summary_datetime_syctimeonconnect">Sincronitza l\'hora en l\'aparell Gadgetbridge quan es connecti o quan es canviï l\'hora o zona horària en l\'aparell Android</string>
     <string name="pref_title_theme">Aparença</string>
     <string name="pref_theme_light">Clar</string>
     <string name="pref_theme_dark">Fosc</string>
-
-    <string name="pref_title_language">Idioma</string>
-
-    <string name="pref_title_minimize_priority">Oculta la notificació de Gadgetbridge</string>
-    <string name="pref_summary_minimize_priority_off">La icona a la barra d\'estat i la notificació a la pantalla de bloqueig estan actius</string>
-    <string name="pref_summary_minimize_priority_on">La icona a la barra d\'estat i la notificació a la pantalla de bloqueig estan ocults</string>
-
+    <string name="pref_title_language">Llengua</string>
+    <string name="pref_title_minimize_priority">Oculta la notificació del Gadgetbridge</string>
+    <string name="pref_summary_minimize_priority_off">La icona a la barra d\'estat i la notificació a la pantalla de bloqueig es mostren</string>
+    <string name="pref_summary_minimize_priority_on">La icona a la barra d\'estat i la notificació a la pantalla de bloqueig no es mostren</string>
     <string name="pref_header_notifications">Notificacions</string>
     <string name="pref_title_notifications_repetitions">Repeticions</string>
     <string name="pref_title_notifications_call">Trucades telefòniques</string>
@@ -102,124 +89,103 @@
     <string name="pref_summary_notifications_pebblemsg">Suport per a aplicacions que envien notificacions a Pebble a través de PebbleKit.</string>
     <string name="pref_title_notifications_generic">Suport per a notificacions genèriques</string>
     <string name="pref_title_whenscreenon">... també amb la pantalla encesa</string>
-    <string name="pref_title_notification_filter">No molestar</string>
-    <string name="pref_summary_notification_filter">Deixar d\'enviar notificacions no desitjades basant-se en el mode No Molestar</string>
-    <string name="pref_title_transliteration">Transcripció</string>
-    <string name="pref_summary_transliteration">Utilitzar en cas que el teu dispositiu no suporti la font del teu idioma</string>
-
+    <string name="pref_title_notification_filter">No molesteu</string>
+    <string name="pref_summary_notification_filter">En aquest mode s\'aturen les notifications no desitjades</string>
+    <string name="pref_title_transliteration">Transliteració</string>
+    <string name="pref_summary_transliteration">Activeu aquesta opció si el vostre aparell no pot mostrar els caràcters de la vostra llengua</string>
     <string name="always">Sempre</string>
     <string name="when_screen_off">Quan la pantalla està apagada</string>
     <string name="never">Mai</string>
-
     <string name="pref_header_privacy">Privacitat</string>
     <string name="pref_title_call_privacy_mode">Mode de privacitat de trucada</string>
-    <string name="pref_call_privacy_mode_off">Mostrar nom i número</string>
-    <string name="pref_call_privacy_mode_name">Oculta nom però mostrar número</string>
-    <string name="pref_call_privacy_mode_number">Ocultar número però mostrar nom</string>
-    <string name="pref_call_privacy_mode_complete">Ocultar nom i número</string>
-
-
-    <string name="pref_blacklist">Llista negra d\'aplicacions</string>
-    <string name="pref_blacklist_calendars">Llista negra de calendaris</string>
-
-    <string name="pref_header_cannned_messages">Missatges predeterminants</string>
+    <string name="pref_call_privacy_mode_off">Mostra el nom i el número</string>
+    <string name="pref_call_privacy_mode_name">Amaga el nom però mostra el número</string>
+    <string name="pref_call_privacy_mode_number">Amaga el número però mostra el nom</string>
+    <string name="pref_call_privacy_mode_complete">Amaga el nom i el número</string>
+    <string name="pref_blacklist">Bloqueig d\'aplicacions</string>
+    <string name="pref_blacklist_calendars">Bloqueig de calendaris</string>
+    <string name="pref_header_cannned_messages">Missatges predefinits</string>
     <string name="pref_title_canned_replies">Respostes</string>
-    <string name="pref_title_canned_reply_suffix">Sufixe habitual</string>
-    <string name="pref_title_canned_messages_dismisscall">Rebutjar trucada</string>
-    <string name="pref_title_canned_messages_set">Actualitza a Pebble</string>
-
-    <string name="pref_header_development">Opcions de desenvolupadors</string>
-    <string name="pref_title_development_miaddr">Direcció de MiBand</string>
-
-    <string name="pref_title_pebble_settings">Paràmetres de Pebble</string>
-
-    <string name="pref_header_activitytrackers">Seguiment d\'activitat</string>
-    <string name="pref_title_pebble_activitytracker">Seguiment d\'activitat preferit</string>
-    <string name="pref_title_pebble_sync_health">Sincronitzar amb Pebble Health</string>
-    <string name="pref_title_pebble_sync_misfit">Sincronitzar amb Misfit</string>
-    <string name="pref_title_pebble_sync_morpheuz">Sincronitzar amb Morpheuz</string>
-
-    <string name="pref_title_enable_outgoing_call">Suport per trucades sortints</string>
+    <string name="pref_title_canned_reply_suffix">Sufix automàtic</string>
+    <string name="pref_title_canned_messages_dismisscall">Rebuig de trucada</string>
+    <string name="pref_title_canned_messages_set">Actualitza al Pebble</string>
+    <string name="pref_header_development">Opcions per a desenvolupadors</string>
+    <string name="pref_title_development_miaddr">Adreça de Mi Band</string>
+    <string name="pref_title_pebble_settings">Configuració del Pebble</string>
+    <string name="pref_header_activitytrackers">Sistemes de seguiment d\'activitat</string>
+    <string name="pref_title_pebble_activitytracker">Sistema preferit per al seguiment d\'activitat</string>
+    <string name="pref_title_pebble_sync_health">Sincronitza amb Pebble Health</string>
+    <string name="pref_title_pebble_sync_misfit">Sincronitza amb Misfit</string>
+    <string name="pref_title_pebble_sync_morpheuz">Sincronitza amb Morpheuz</string>
+    <string name="pref_title_enable_outgoing_call">Suport per a trucades sortints</string>
     <string name="pref_summary_enable_outgoing_call">Desactivar això evitarà que Pebble 2/LE vibri en trucades sortints</string>
-
-    <string name="pref_title_enable_pebblekit">Permetre l\'accés a aplicacions Android de tercers</string>
-    <string name="pref_summary_enable_pebblekit">Permetre el suport experimental per aplicacions Android que fan servir PebbleKit</string>
-
-    <string name="pref_header_pebble_timeline">Timeline Pebble</string>
+    <string name="pref_title_enable_pebblekit">Permet l\'accés a aplicacions Android de tercers</string>
+    <string name="pref_summary_enable_pebblekit">Permet aplicacions d\'Android experimentals que fan servir PebbleKit</string>
+    <string name="pref_header_pebble_timeline">Cronologia del Pebble</string>
     <string name="pref_title_sunrise_sunset">Sortida i posta de sol</string>
-    <string name="pref_summary_sunrise_sunset">Envia les hores de sortida i posta de sol basant-se en la localització a la timeline del Pebble</string>
-    <string name="pref_title_enable_calendar_sync">Sincronitzar calendari</string>
-    <string name="pref_summary_enable_calendar_sync">Envia els esdeveniments del calendari a la línia de temps</string>
-
-    <string name="pref_title_autoremove_notifications">Esborra automàticament les notificacions rebutjades</string>
-    <string name="pref_summary_autoremove_notifications">Les notificacions s\'esborren automàticament de Pebble quan es rebutgen a Android</string>
-
-    <string name="pref_title_pebble_privacy_mode">Mode privat</string>
-    <string name="pref_pebble_privacy_mode_off">Notificació normal</string>
+    <string name="pref_summary_sunrise_sunset">Envia les hores de sortida i posta de sol basades en la ubicació a la cronologia del Pebble</string>
+    <string name="pref_title_enable_calendar_sync">Sincronitza el calendari</string>
+    <string name="pref_summary_enable_calendar_sync">Envia els esdeveniments del calendari a la cronologia</string>
+    <string name="pref_title_autoremove_notifications">Suprimeix automàticament les notificacions rebutjades</string>
+    <string name="pref_summary_autoremove_notifications">Les notificacions se suprimeixen automàticament del Pebble quan es rebutgen a l\'aparell Android</string>
+    <string name="pref_title_pebble_privacy_mode">Mode de privacitat</string>
+    <string name="pref_pebble_privacy_mode_off">Notificacions normals</string>
     <string name="pref_pebble_privacy_mode_content">Desplaça la notificació fora de la pantalla</string>
-    <string name="pref_pebble_privacy_mode_complete">Mostra només la icona de notificació</string>
-
-    <string name="pref_header_location">Localització</string>
-    <string name="pref_title_location_aquire">Obtenir localització</string>
+    <string name="pref_pebble_privacy_mode_complete">Mostra només la icona de la notificació</string>
+    <string name="pref_header_location">Ubicació</string>
+    <string name="pref_title_location_aquire">Obté la localització</string>
     <string name="pref_title_location_latitude">Latitud</string>
     <string name="pref_title_location_longitude">Longitud</string>
-    <string name="pref_title_location_keep_uptodate">Mantenir la localització actualitzada</string>
-    <string name="pref_summary_location_keep_uptodate">Intentar aconseguir la localització en marxa, fer servir la desada com a alternatiu</string>
-
-    <string name="toast_enable_networklocationprovider">Si us plau, activa la localització per xarxa</string>
-    <string name="toast_aqurired_networklocation">Localització trobada</string>
-
-    <string name="pref_title_pebble_forceprotocol">Forçar el protocol de notificació</string>
-    <string name="pref_summary_pebble_forceprotocol">Aquesta opció força l\'ús del darrer protocol de notificació en funció de la versió del firmware. ACTIVA-HO NOMÉS SI SAPS EL QUE ESTÀS FENT!</string>
-    <string name="pref_title_pebble_forceuntested">Activar característiques no provades</string>
-    <string name="pref_summary_pebble_forceuntested">Activar les característiques que no han estat provades. ACTIVA-HO NOMÉS SI SAPS EL QUE ESTÀS FENT!</string>
-    <string name="pref_title_pebble_forcele">Preferir sempre BLE</string>
-    <string name="pref_summary_pebble_forcele">Utilitza el suport experimental de Pebble LE a tots els Pebble en lloc del Bluetooth clàssic, la qual cosa requereix vincular \"Pebble LE\" si un Pebble no-LI ha estat vinculat abans</string>
-    <string name="pref_title_pebble_mtu_limit">Pebble 2/LI límit de GATT MTU</string>
-    <string name="pref_summary_pebble_mtu_limit">Si el teu Pebble 2/Pebble LE no funciona correctament, prova aquesta opció per limitar l\'MTU (rang vàlid 20-512)</string>
+    <string name="pref_title_location_keep_uptodate">Mantingues la ubicació actualitzada</string>
+    <string name="pref_summary_location_keep_uptodate">Intenta aconseguir la ubicació constantment, i si això no és possible fes servir la ubicació desada prèviament</string>
+    <string name="toast_enable_networklocationprovider">Si us plau, activeu la ubicació per xarxa</string>
+    <string name="toast_aqurired_networklocation">S\'ha trobat la ubicació</string>
+    <string name="pref_title_pebble_forceprotocol">Força el protocol de notificació</string>
+    <string name="pref_summary_pebble_forceprotocol">Aquesta opció força l\'ús del darrer protocol de notificació en funció de la versió del microprogramari. VIGILEU AMB EL QUE FEU!</string>
+    <string name="pref_title_pebble_forceuntested">Activa característiques no provades</string>
+    <string name="pref_summary_pebble_forceuntested">Activa les característiques que no han estat provades. VIGILEU AMB EL QUE FEU!</string>
+    <string name="pref_title_pebble_forcele">Prefereix sempre BLE</string>
+    <string name="pref_summary_pebble_forcele">Utilitza el suport experimental de Pebble LE a tots els Pebble, enlloc del Bluetooth clàssic. Primer cal aparellar primer un Pebble sense LE i després un Pebble LE</string>
+    <string name="pref_title_pebble_mtu_limit">Límit de l\'MTU del GATT del Pebble 2/LE</string>
+    <string name="pref_summary_pebble_mtu_limit">Si el teu Pebble 2/Pebble LE no funciona correctament, prova aquesta opció per limitar l\'MTU (rang vàlid: 20-512)</string>
     <string name="pref_title_pebble_enable_applogs">Activa els registres de les aplicacions del rellotge</string>
-    <string name="pref_summary_pebble_enable_applogs">Produirà registres de les apps del rellotge que Gadgetbridge guardarà (necessita reconnexió)</string>
-    <string name="pref_title_pebble_always_ack_pebblekit">ACK abans d\'hora de PebbleKit</string>
-    <string name="pref_summary_pebble_always_ack_pebblekit">Permetrà als missatges enviats a apps de tercers ser reconeguts sempre i immediatament</string>
+    <string name="pref_summary_pebble_enable_applogs">Produirà registres de les apps del rellotge que el Gadgetbridge guardarà (necessita reconnexió)</string>
+    <string name="pref_title_pebble_always_ack_pebblekit">Envia l\'ACK al PebbleKit abans d\'hora</string>
+    <string name="pref_summary_pebble_always_ack_pebblekit">Permetrà que missatges enviats a aplicacions de tercers siguin reconeguts sempre i immediatament</string>
     <string name="pref_title_pebble_enable_bgjs">Activa JS en segon pla</string>
-    <string name="pref_summary_pebble_enable_bgjs">Permet a les pantalles mostrar el temps, informació de bateria, etc.</string>
-
-    <string name="pref_title_pebble_reconnect_attempts">Intents de reconnexions</string>
-
-    <string name="pref_title_unit_system">Preferències HPlus</string>
+    <string name="pref_summary_pebble_enable_bgjs">Permet a les caràtules mostrar el temps, informació de bateria, etc.</string>
+    <string name="pref_title_pebble_reconnect_attempts">Intents de reconnexió</string>
+    <string name="pref_title_unit_system">Unitats</string>
     <string name="pref_title_timeformat">Format d\'hora</string>
-    <string name="pref_title_screentime">Temps de pantalla encesa</string>
+    <string name="pref_title_screentime">Durada de pantalla encesa</string>
     <string name="prefs_title_all_day_heart_rate">Mesura el ritme cardíac tot el dia</string>
-    <string name="preferences_hplus_settings">Paràmetres HPlus/Makibes</string>
-
+    <string name="preferences_hplus_settings">Configuració de HPlus/Makibes</string>
     <string name="not_connected">No connectat</string>
-    <string name="connecting">Connectant</string>
+    <string name="connecting">S\'està connectant</string>
     <string name="connected">Connectat</string>
     <string name="unknown_state">Estat desconegut</string>
     <string name="_unknown_">(desconegut)</string>
     <string name="test">Prova</string>
-    <string name="test_notification">Prova notificació</string>
-    <string name="this_is_a_test_notification_from_gadgetbridge">Això és una notificació de prova des de Gadgetbridge</string>
-    <string name="bluetooth_is_not_supported_">El Bluetooth no està suportat.</string>
-    <string name="bluetooth_is_disabled_">El Bluetooth està inhabilitat.</string>
-    <string name="tap_connected_device_for_app_mananger">Fes un toc al dispositiu connectat per a configurar les aplicacions</string>
-    <string name="tap_connected_device_for_activity">Fes un toc al dispositiu connectat per activitat</string>
-    <string name="tap_connected_device_for_vibration">Fes un toc al dispositiu per vibració</string>
-    <string name="tap_a_device_to_connect">Fes un toc a un dispositius per connectar</string>
-    <string name="cannot_connect_bt_address_invalid_">No és pot connectar. Direcció BT incorrecta?</string>
-    <string name="gadgetbridge_running">Gadgetbridge funcionant</string>
-    <string name="installing_binary_d_d">Instal·lat binari %1$d/%2$d</string>
+    <string name="test_notification">Notificació de prova</string>
+    <string name="this_is_a_test_notification_from_gadgetbridge">Això és una notificació de prova des del Gadgetbridge</string>
+    <string name="bluetooth_is_not_supported_">El Bluetooth no és compatible o no està implementat.</string>
+    <string name="bluetooth_is_disabled_">El Bluetooth està desactivat.</string>
+    <string name="tap_connected_device_for_app_mananger">Toca el dispositiu connectat per obrir el gestor d\'aplicacions</string>
+    <string name="tap_connected_device_for_activity">Toca el dispositiu connectat per gestionar-ne l\'activitat</string>
+    <string name="tap_connected_device_for_vibration">Toca el dispositiu per fer-lo vibrar</string>
+    <string name="tap_a_device_to_connect">Toca un aparell per connectar-hi</string>
+    <string name="cannot_connect_bt_address_invalid_">No es pot connectar. Potser la direcció Bluetooth és incorrecta\?</string>
+    <string name="gadgetbridge_running">El Gadgetbridge està funcionant</string>
+    <string name="installing_binary_d_d">S\'està instal·lant el binari %1$d/%2$d</string>
     <string name="installation_failed_">La instal·lació ha fallat</string>
-    <string name="installation_successful">Instal·lació correcta</string>
+    <string name="installation_successful">Instal·lat</string>
     <string name="pref_title_weather">El temps</string>
     <string name="pref_title_weather_location">Ubicació del temps (CM/LOS)</string>
-
     <string name="pref_header_auto_export">Exportació automàtica</string>
     <string name="pref_title_auto_export_enabled">Exportació automàtica activada</string>
     <string name="pref_title_auto_export_location">Ubicació de l\'exportació</string>
     <string name="pref_title_auto_export_interval">Interval de l\'exportació</string>
     <string name="pref_summary_auto_export_interval">Exporta cada %d hores</string>
-
     <string name="app_install_info">Esteu a punt d\'instal·lar la següent aplicació:
 \n
 \n
@@ -227,22 +193,21 @@
     <string name="n_a">NO DISPONIBLE</string>
     <string name="initialized">inicialitzat</string>
     <string name="appversion_by_creator">%1$s per %2$s</string>
-    <string name="title_activity_discovery">Detecció de dispositius</string>
-
+    <string name="title_activity_discovery">Detecció d\'aparells</string>
     <string name="discovery_stop_scanning">Atura l\'escaneig</string>
     <string name="discovery_start_scanning">Inicia la detecció</string>
-    <string name="action_discover">Connecteu un dispositiu nou</string>
+    <string name="action_discover">Connecta un aparell nou</string>
     <string name="device_with_rssi">%1$s (%2$s)</string>
-    <string name="title_activity_android_pairing">Emparelleu el dispositiu</string>
-    <string name="android_pairing_hint">Utilitza el diàleg d\'emparellament Android Bluetooth per emparellar el dispositiu.</string>
-    <string name="title_activity_mi_band_pairing">Emparelleu Mi Band</string>
-    <string name="pairing">Emparellant amb %s…</string>
-    <string name="pairing_creating_bond_with">Creant vincle amb %1$s (%2$s)</string>
-    <string name="pairing_unable_to_pair_with">No s\'ha pogut emparellar amb %1$s (%2$s)</string>
-    <string name="pairing_in_progress">Emparellament en curs: %1$s (%2$s)</string>
-    <string name="pairing_already_bonded">Ja emparellat amb %1$s (%2$s), connectant…</string>
-    <string name="message_cannot_pair_no_mac">No s\'ha obtingut cap adreça MAC. No es pot emparellar.</string>
-    <string name="preferences_category_device_specific_settings">Configuració específica del dispositiu</string>
+    <string name="title_activity_android_pairing">Aparella l\'aparell</string>
+    <string name="android_pairing_hint">Utilitzeu el diàleg d\'aparellament Bluetooth de l\'Android per aparellar l\'aparell.</string>
+    <string name="title_activity_mi_band_pairing">Aparelleu la vostra Mi Band</string>
+    <string name="pairing">S\'està aparellant amb %s…</string>
+    <string name="pairing_creating_bond_with">S\'està creant un vincle amb %1$s (%2$s)</string>
+    <string name="pairing_unable_to_pair_with">No s\'ha pogut aparellar amb %1$s (%2$s)</string>
+    <string name="pairing_in_progress">Aparellament en curs: %1$s (%2$s)</string>
+    <string name="pairing_already_bonded">Ja s\'ha aparellat amb %1$s (%2$s). Connectant…</string>
+    <string name="message_cannot_pair_no_mac">No s\'ha proporcionat cap adreça MAC. No es pot emparellar.</string>
+    <string name="preferences_category_device_specific_settings">Configuració d\'aparells específics</string>
     <string name="preferences_miband_settings">Configuració de Mi Band / Amazfit</string>
     <string name="preferences_amazfitbip_settings">Configuració d\'Amazfit Bip</string>
     <string name="male">Home</string>
@@ -252,28 +217,25 @@
     <string name="right">Dreta</string>
     <string name="appinstaller_install">Instal·la</string>
     <string name="discovery_note">Nota:</string>
-    <string name="candidate_item_device_image">Imatge de dispositiu</string>
+    <string name="candidate_item_device_image">Imatge de l\'aparell</string>
     <string name="miband_prefs_alias">Nom/Àlies</string>
     <string name="pref_header_vibration_count">Recompte de vibracions</string>
-
     <string name="title_activity_sleepmonitor">Monitor de son</string>
     <string name="pref_write_logfiles">Escriu fitxers de registre</string>
     <string name="initializing">S\'està inicialitzant</string>
-    <string name="busy_task_fetch_activity_data">S\'està obtenint les dades d\'activitat</string>
-    <string name="sleep_activity_date_range">Des de %1$s a %2$s</string>
-    <string name="miband_prefs_wearside">Rellotge a l\'esquerra o la dreta?</string>
+    <string name="busy_task_fetch_activity_data">S\'estàn recollint les dades d\'activitat</string>
+    <string name="sleep_activity_date_range">De %1$s a %2$s</string>
+    <string name="miband_prefs_wearside">A quina mà porteu l\'aparell\?</string>
     <string name="pref_screen_vibration_profile">Perfil de vibració</string>
-
-    <string name="vibration_profile_staccato">Molt curt</string>
-    <string name="vibration_profile_short">Curt</string>
-    <string name="vibration_profile_medium">Mitjà</string>
-    <string name="vibration_profile_long">Llarg</string>
-    <string name="vibration_profile_waterdrop">Molt llarg</string>
+    <string name="vibration_profile_staccato">Molt curta</string>
+    <string name="vibration_profile_short">Curta</string>
+    <string name="vibration_profile_medium">Mitjana</string>
+    <string name="vibration_profile_long">Llarga</string>
+    <string name="vibration_profile_waterdrop">Gota d\'aigua</string>
     <string name="vibration_profile_ring">Timbre</string>
-    <string name="vibration_profile_alarm_clock">Alarma</string>
+    <string name="vibration_profile_alarm_clock">Despertador</string>
     <string name="miband_prefs_vibration">Vibració</string>
-
-    <string name="vibration_try">Proveu-ho</string>
+    <string name="vibration_try">Prova-ho</string>
     <string name="pref_screen_notification_profile_sms">Notificació de SMS</string>
     <string name="pref_header_vibration_settings">Configuració de vibració</string>
     <string name="pref_screen_notification_profile_generic">Notificació genèrica</string>
@@ -282,23 +244,20 @@
     <string name="pref_screen_notification_profile_generic_chat">Xat</string>
     <string name="pref_screen_notification_profile_generic_navigation">Navegació</string>
     <string name="pref_screen_notification_profile_generic_social">Xarxa social</string>
-
-    <string name="prefs_title_heartrate_measurement_interval">Mesura del ritme cardíac tot el dia</string>
-    <string name="interval_one_minute">cada minut</string>
-    <string name="interval_five_minutes">Cada 5 minuts</string>
-    <string name="interval_ten_minutes">Cada 10 minuts</string>
-    <string name="interval_thirty_minutes">Cada 30 minuts</string>
-    <string name="interval_one_hour">Cada hora</string>
-
+    <string name="prefs_title_heartrate_measurement_interval">Mesura el ritme cardíac tot el dia</string>
+    <string name="interval_one_minute">una vegada per minut</string>
+    <string name="interval_five_minutes">cada 5 minuts</string>
+    <string name="interval_ten_minutes">cada 10 minuts</string>
+    <string name="interval_thirty_minutes">cada 30 minuts</string>
+    <string name="interval_one_hour">cada hora</string>
     <string name="stats_title">Zones de velocitat</string>
     <string name="stats_x_axis_label">Minuts totals</string>
-    <string name="stats_y_axis_label">Passos per minut</string>
-
-    <string name="control_center_find_lost_device">Troba el dispositiu perdut</string>
+    <string name="stats_y_axis_label">Passes per minut</string>
+    <string name="control_center_find_lost_device">Troba l\'aparell perdut</string>
     <string name="control_center_cancel_to_stop_vibration">Cancel·leu per aturar la vibració.</string>
     <string name="title_activity_charts">La vostra activitat</string>
-    <string name="title_activity_set_alarm">Configureu les alarmes</string>
-    <string name="controlcenter_start_configure_alarms">Configureu les alarmes</string>
+    <string name="title_activity_set_alarm">Configura les alarmes</string>
+    <string name="controlcenter_start_configure_alarms">Configura les alarmes</string>
     <string name="title_activity_alarm_details">Detalls d\'alarma</string>
     <string name="alarm_sun_short">Dg.</string>
     <string name="alarm_mon_short">Dl.</string>
@@ -307,30 +266,30 @@
     <string name="alarm_thu_short">Dj.</string>
     <string name="alarm_fri_short">Dv.</string>
     <string name="alarm_sat_short">Ds.</string>
-    <string name="alarm_smart_wakeup">Alarma intel·ligent</string>
-    <string name="user_feedback_miband_set_alarms_failed">Hi ha hagut un error en posar les alarmes. Si us plau, intenteu-ho de nou!</string>
-    <string name="user_feedback_miband_set_alarms_ok">Les alarmes han sigut enviades al dispositiu!</string>
-    <string name="chart_no_data_synchronize">No hi ha dades. Sincronitzo el dispositiu?</string>
+    <string name="alarm_smart_wakeup">Reactivació intel·ligent</string>
+    <string name="user_feedback_miband_set_alarms_failed">Hi ha hagut un error en definir les alarmes. Si us plau, intenteu-ho de nou.</string>
+    <string name="user_feedback_miband_set_alarms_ok">S\'han enviat les alarmes a l\'aparell.</string>
+    <string name="chart_no_data_synchronize">No hi ha dades. Sincronitzo l\'aparell\?</string>
     <string name="user_feedback_miband_activity_data_transfer">A punt de transferir %1$s de dades des de %2$s</string>
-    <string name="miband_prefs_fitness_goal">Objectiu de passos diaris</string>
+    <string name="miband_prefs_fitness_goal">Objectiu de passes diàries</string>
     <string name="dbaccess_error_executing">Error en executar \'%1$s\'</string>
     <string name="controlcenter_start_activitymonitor">La vostra activitat (ALPHA)</string>
     <string name="cannot_connect">No es pot connectar: %1$s</string>
-    <string name="installer_activity_unable_to_find_handler">No s\'ha trobar un controlador per instal·lar el fitxer.</string>
+    <string name="installer_activity_unable_to_find_handler">No s\'ha trobat cap controlador per instal·lar aquest fitxer.</string>
     <string name="pbw_install_handler_unable_to_install">No s\'ha pogut instal·lar el fitxer: %1$s</string>
-    <string name="pbw_install_handler_hw_revision_mismatch">No s\'ha pogut instal·lar el microprogramari: no coincideix amb revisió del maquinari de Peeble.</string>
-    <string name="installer_activity_wait_while_determining_status">Si us plau, espereu mentre que es determina l\'estat de la instal·lació…</string>
-    <string name="notif_battery_low_title">Bateria del gadget baixa!</string>
-    <string name="notif_battery_low_percent">A %1$s li roman: %2$s%% de bateria</string>
+    <string name="pbw_install_handler_hw_revision_mismatch">No s\'ha pogut instal·lar el microprogramari: no coincideix amb la revisió de maquinari del vostre Pebble.</string>
+    <string name="installer_activity_wait_while_determining_status">Si us plau, espereu mentre s\'esbrina l\'estat de la instal·lació…</string>
+    <string name="notif_battery_low_title">L\'aparell té poca bateria!</string>
+    <string name="notif_battery_low_percent">A %1$s li roman un %2$s%% de bateria</string>
     <string name="notif_battery_low_bigtext_last_charge_time">Darrera càrrega: %s</string>
     <string name="notif_battery_low_bigtext_number_of_charges">Nombre de càrregues: %s</string>
     <string name="notif_export_failed_title">L\'exportació de la base de dades ha fallat! Si us plau, comproveu la configuració.</string>
     <string name="sleepchart_your_sleep">El vostre son</string>
     <string name="weeksleepchart_sleep_a_week">Son per setmana</string>
     <string name="weeksleepchart_today_sleep_description">Son avui, objectiu: %1$s</string>
-    <string name="weekstepschart_steps_a_week">Passos per setmana</string>
-    <string name="activity_sleepchart_activity_and_sleep">La vostra activitat i son</string>
-    <string name="updating_firmware">El microprogramari s\'està actualitzant…</string>
+    <string name="weekstepschart_steps_a_week">Passes per setmana</string>
+    <string name="activity_sleepchart_activity_and_sleep">La vostra activitat i el vostre son</string>
+    <string name="updating_firmware">El microprogramari s\'està instal·lant…</string>
     <string name="fwapp_install_device_not_ready">No es pot instal·lar el fitxer. El dispositiu no està preparat.</string>
     <string name="installhandler_firmware_name">%1$s: %2$s %3$s</string>
     <string name="miband_fwinstaller_compatible_version">Versió compatible</string>
@@ -340,99 +299,415 @@
     <string name="pbwinstallhandler_correct_hw_revision">Revisió del maquinari correcta</string>
     <string name="pbwinstallhandler_incorrect_hw_revision">La revisió del maquinari no coincideix!</string>
     <string name="pbwinstallhandler_app_item">%1$s (%2$s)</string>
-    <string name="updatefirmwareoperation_updateproblem_do_not_reboot">Hi ha hagut un problema amb la transferència del microprogramari. NO REINICIEU Mi Band!</string>
+    <string name="updatefirmwareoperation_updateproblem_do_not_reboot">Hi ha hagut un problema amb la transferència del microprogramari. NO REINICIEU la vostra Mi Band!</string>
     <string name="updatefirmwareoperation_metadata_updateproblem">Hi ha hagut un problema amb la transferència de metadades del microprogramari</string>
     <string name="updatefirmwareoperation_update_complete">S\'ha completat la instal·lació del microprogramari</string>
-    <string name="updatefirmwareoperation_update_complete_rebooting">S\'ha completat la instal·lació del microprogramari. Es va a reiniciar el dispositiu…</string>
+    <string name="updatefirmwareoperation_update_complete_rebooting">S\'ha completat la instal·lació del microprogramari. S\'està reiniciant l\'aparell…</string>
     <string name="updatefirmwareoperation_write_failed">La instal·lació del microprogramari ha fallat</string>
-    <string name="chart_steps">Passos</string>
+    <string name="chart_steps">Passes</string>
     <string name="calories">Calories</string>
     <string name="distance">Distància</string>
     <string name="clock">Rellotge</string>
-    <string name="heart_rate">Freqüència cardíaca</string>
+    <string name="heart_rate">Ritme cardíac</string>
     <string name="battery">Bateria</string>
-    <string name="liveactivity_live_activity">Activitat en directe</string>
-    <string name="weeksteps_today_steps_description">Passos avui, objectiu: %1$s</string>
+    <string name="liveactivity_live_activity">Activitat en temps real</string>
+    <string name="weeksteps_today_steps_description">Passes avui, objectiu: %1$s</string>
     <string name="pref_title_low_latency_fw_update">Utilitza el mode de baixa latència per actualitzar el microprogramari</string>
-    <string name="pref_summary_low_latency_fw_update">Això podria ajudar en dispositius on l\'actualització del microprogramari falla</string>
-
-    <string name="live_activity_steps_history">Historial de passos</string>
-    <string name="live_activity_current_steps_per_minute">Passos actuals / min</string>
-    <string name="live_activity_total_steps">Passos totals</string>
-    <string name="live_activity_steps_per_minute_history">Historial de passos per minut</string>
+    <string name="pref_summary_low_latency_fw_update">Això podria ajudar en aparells on l\'actualització del microprogramari falla.</string>
+    <string name="live_activity_steps_history">Historial de passes</string>
+    <string name="live_activity_current_steps_per_minute">Passes actuals / min</string>
+    <string name="live_activity_total_steps">Passes totals</string>
+    <string name="live_activity_steps_per_minute_history">Historial de passes per minut</string>
     <string name="live_activity_start_your_activity">Inicieu la vostra activitat</string>
     <string name="abstract_chart_fragment_kind_activity">Activitat</string>
     <string name="abstract_chart_fragment_kind_light_sleep">Son lleuger</string>
     <string name="abstract_chart_fragment_kind_deep_sleep">Son profund</string>
     <string name="abstract_chart_fragment_kind_not_worn">No portat</string>
     <string name="device_not_connected">No connectat.</string>
-    <string name="user_feedback_all_alarms_disabled">Totes les alarmes són desactivades</string>
-    <string name="pref_title_keep_data_on_device">Manté les dades d\'activitat al dispositiu</string>
+    <string name="user_feedback_all_alarms_disabled">Totes les alarmes estan desactivades</string>
+    <string name="pref_title_keep_data_on_device">Mantingues les dades d\'activitat a l\'aparell</string>
     <string name="miband_fwinstaller_incompatible_version">Microprogramari incompatible</string>
-    <string name="fwinstaller_firmware_not_compatible_to_device">Aquest microprogramari no és compatible amb el dispositiu</string>
-    <string name="miband_prefs_reserve_alarm_calendar">Alarmes de reserva per als propers esdeveniments</string>
+    <string name="fwinstaller_firmware_not_compatible_to_device">Aquest microprogramari no és compatible amb l\'aparell</string>
+    <string name="miband_prefs_reserve_alarm_calendar">Alarmes a reservar per a esdeveniments futurs</string>
     <string name="miband_prefs_hr_sleep_detection">Utilitza el sensor de ritme cardíac per millorar la detecció del son</string>
-	<string name="miband_prefs_device_time_offset_hours">Temps de desplaçament en hores del dispositiu (per detectar el son de treballadors/es de torns)</string>
-    <string name="miband2_prefs_dateformat">Mi2: format de data</string>
+    <string name="miband_prefs_device_time_offset_hours">Desplaçament de temps de l\'aparell, en hores (per detectar el son de treballadors/es de torns)</string>
+    <string name="miband2_prefs_dateformat">Format de data</string>
     <string name="dateformat_time">Temps</string>
     <string name="dateformat_date_time">Hora i data</string>
-    <string name="mi2_prefs_button_actions">Accions dels botó</string>
-    <string name="mi2_prefs_button_actions_summary">Especifiqueu les accions en prémer el botó del Mi Band 2</string>
-    <string name="mi2_prefs_button_press_count">Compte de pulsacions del botó</string>
-    <string name="mi2_prefs_button_press_count_summary">Nombre de pulsacions del botó per activar la difusió de missatge</string>
+    <string name="mi2_prefs_button_actions">Accions del botó</string>
+    <string name="mi2_prefs_button_actions_summary">Especifiqueu les accions en prémer el botó de la Mi Band 2</string>
+    <string name="mi2_prefs_button_press_count">Nombre de pulsacions del botó</string>
+    <string name="mi2_prefs_button_press_count_summary">Nombre de vegades que cal prémer el botó per activar la difusió de missatge</string>
     <string name="mi2_prefs_button_press_broadcast">Missatge de difusió a enviar</string>
     <string name="mi2_prefs_button_action">Activa el botó d\'acció</string>
-    <string name="mi2_prefs_button_action_summary">Activa l\'acció en fer el nombre de pulsacions especificades del botó</string>
-    <string name="mi2_prefs_button_action_vibrate">Activa la vibració de la pulsera</string>
+    <string name="mi2_prefs_button_action_summary">Activa un acció en prémer un botó un cert nombre de vegades</string>
+    <string name="mi2_prefs_button_action_vibrate">Activa la vibració de la polsera</string>
     <string name="mi2_prefs_button_action_vibrate_summary">Activa la vibració de la pulsera en prémer el botó d\'acció</string>
     <string name="mi2_prefs_button_press_count_max_delay">Retard màxim entre pulsacions</string>
     <string name="mi2_prefs_button_press_count_max_delay_summary">Retard màxim entre pulsacions del botó en mil·lisegons</string>
     <string name="mi2_prefs_button_press_count_match_delay">Retard després de l\'acció de botó</string>
     <string name="mi2_prefs_goal_notification">Notificació d\'objectiu</string>
-    <string name="mi2_prefs_goal_notification_summary">La banda vibrarà quan l\'objectiu diari de passos siga assolit</string>
+    <string name="mi2_prefs_goal_notification_summary">La polsera vibrarà quan l\'objectiu diari de passes siga assolit</string>
     <string name="mi2_prefs_display_items">Elements a mostrar</string>
-    <string name="mi2_prefs_display_items_summary">Escolliu els elements a mostrar en la pantalla del rellotge</string>
+    <string name="mi2_prefs_display_items_summary">Escolliu els elements a mostrar en la pantalla de la polsera</string>
     <string name="mi2_prefs_activate_display_on_lift">Activa la pantalla en alçar-la</string>
     <string name="mi2_prefs_rotate_wrist_to_switch_info">Gira el canell per canviar la informació</string>
-    <string name="mi2_prefs_do_not_disturb">No molestis</string>
-    <string name="mi2_prefs_do_not_disturb_summary">La pulsera no rebrà notificacions mentre siga activa</string>
+    <string name="mi2_prefs_do_not_disturb">No molesteu</string>
+    <string name="mi2_prefs_do_not_disturb_summary">La polsera no rebrà notificacions mentre aquesta opció estigui activada</string>
     <string name="mi2_prefs_inactivity_warnings">Avisos d\'inactivitat</string>
-    <string name="mi2_prefs_inactivity_warnings_summary">La banda vibrarà quan hàgiu estat inactius durant una estona</string>
+    <string name="mi2_prefs_inactivity_warnings_summary">La polsera vibrarà quan hàgiu estat inactius durant una estona</string>
     <string name="mi2_prefs_inactivity_warnings_threshold">Llindar d\'inactivitat (en minuts)</string>
     <string name="mi2_prefs_inactivity_warnings_dnd_summary">Desactiva els avisos d\'inactivitat durant un interval de temps</string>
     <string name="mi2_prefs_do_not_disturb_start">Hora d\'inici</string>
     <string name="mi2_prefs_do_not_disturb_end">Hora de finalització</string>
-
     <string name="automatic">Automàtic</string>
     <string name="simplified_chinese">Xinès simplificat</string>
     <string name="traditional_chinese">Xinès tradicional</string>
     <string name="english">Anglès</string>
-    <string name="spanish">Espanyol</string>
-
+    <string name="spanish">Castellà</string>
     <string name="FetchActivityOperation_about_to_transfer_since">A punt de transferir dades des de %1$s</string>
-
-    <string name="waiting_for_reconnect">Esperant a reconectar</string>
-
+    <string name="waiting_for_reconnect">S\'està esperant per reconectar</string>
     <string name="activity_prefs_about_you">Quant a tu</string>
     <string name="activity_prefs_year_birth">Any de naixement</string>
-    <string name="activity_prefs_gender">Sexe</string>
+    <string name="activity_prefs_gender">Gènere</string>
     <string name="activity_prefs_height_cm">Alçada en cm</string>
     <string name="activity_prefs_weight_kg">Pes en kg</string>
-
     <string name="authenticating">S\'està autenticant</string>
     <string name="authentication_required">Es requereix autenticació</string>
-
     <string name="appwidget_text">Zzz</string>
     <string name="add_widget">Afegeix un giny</string>
     <string name="activity_prefs_sleep_duration">Duració preferida del son en hores</string>
-    <string name="appwidget_setting_alarm">S\'ha creat una alarma a les %1$02d:%2$02d</string>
+    <string name="appwidget_setting_alarm">S\'ha fixat una alarma a les %1$02d:%2$02d</string>
     <string name="device_hw">Revisió del maquinari: %1$s</string>
     <string name="device_fw">Versió del microprogramari: %1$s</string>
-    <string name="error_creating_directory_for_logfiles">S\'ha produït un error al crear un directori per als fitxers de registre: %1$s</string>
-    <string name="DEVINFO_HR_VER">Activitat cardiaca</string>
-    <string name="updatefirmwareoperation_update_in_progress">S\'està actualitzant el programari</string>
+    <string name="error_creating_directory_for_logfiles">S\'ha produït un error en crear un directori per als fitxers de registre: %1$s</string>
+    <string name="DEVINFO_HR_VER">"Ritme cardíac: "</string>
+    <string name="updatefirmwareoperation_update_in_progress">S\'està instal·lant el microprogramari</string>
     <string name="updatefirmwareoperation_firmware_not_sent">No s\'ha enviat el microprogramari</string>
-    <string name="charts_legend_heartrate">Freqüència cardíaca</string>
-    <string name="live_activity_heart_rate">Freqüència cardíaca</string>
-
-    </resources>
+    <string name="charts_legend_heartrate">Ritme cardíac</string>
+    <string name="live_activity_heart_rate">Ritme cardíac</string>
+    <string name="pref_title_pebble_gatt_clientonly">Només client GATT</string>
+    <string name="pref_summary_pebble_gatt_clientonly">Això només és per a Pebble 2 i és experimental. Proveu-ho si teniu problemes de connexió</string>
+    <string name="fw_upgrade_notice_miband3">Sou a punt d\'instal·lar el microprogramari %s en la vostra Mi Band 3.
+\n
+\nSi us plau, assegureu-vos d\'instal·lar el fitxer .fw, i després el fitxer .res. El vostre rellotge es reiniciarà després d\'instal·lar el fitxer .fw.
+\n
+\nObservació: No cal que instal·leu el fitxer .res si és exactament el mateix que ja estava instal·lat.
+\n
+\nPROCEDIU SOTA LA VOSTRA PRÒPIA RESPONSABILITAT!</string>
+    <string name="blacklist_all_for_notifications">Bloqueja totes les notifications</string>
+    <string name="whitelist_all_for_notifications">Permet totes les notificacions</string>
+    <string name="preferences_id115_settings">Configuració de ID115</string>
+    <string name="prefs_screen_orientation">Orientació de la pantalla</string>
+    <string name="controlcenter_calibrate_device">Calibra l\'aparell</string>
+    <string name="pref_title_notifications_timeout">Temps mínim entre notificacions</string>
+    <string name="controlcenter_change_led_color">Canvia el color del LED</string>
+    <string name="controlcenter_change_fm_frequency">Canvia la freqüència FM</string>
+    <string name="pref_title_rtl">De dreta a esquerra</string>
+    <string name="pref_summary_rtl">Activeu això si el vostre aparell no pot mostrar llengües que s\'escriuen de dreta esquerra</string>
+    <string name="pref_rtl_max_line_length">Llargada màxima de línia de dreta a esquerra</string>
+    <string name="pref_rtl_max_line_length_summary">Allarga o escurça les línies en què se separa el text escrit de dreta a esquerra</string>
+    <string name="debugactivity_really_factoryreset_title">De debò voleu restablir als paràmetres de fàbrica\?</string>
+    <string name="debugactivity_really_factoryreset">Restablir als paràmetres de fàbrica esborrarà totes les dades de l\'aparell connectat (si és compatible). En el cas dels aparells Xiaomi o Huami, també canvia la seva adreça MAC, de manera que per al Gadgetbridge apareixeran com a un aparell nou.</string>
+    <string name="zetime_title_settings">Configuració de ZeTime</string>
+    <string name="zetime_title_heartrate">Configuració del rítme cardíac</string>
+    <string name="zetime_title_screentime">Durada de la pantalla encesa en segons</string>
+    <string name="zetime_title_heart_rate_alarm">Alarma del ritme cardíac</string>
+    <string name="zetime_title_heart_rate_alarm_summary">El rellotge us avisarà quan el vostre ritme cardíac superi els límits.</string>
+    <string name="zetime_heart_rate_alarm_enable">Activa l\'alarma del ritme cardíac</string>
+    <string name="activity_prefs_alarm_max_heart_rate">Ritme cardíac màxim</string>
+    <string name="activity_prefs_alarm_min_heart_rate">Ritme cardíac mínim</string>
+    <string name="zetime_analog_mode">Mode analògic</string>
+    <string name="zetime_analog_mode_hands">Només mans</string>
+    <string name="zetime_analog_mode_handsandsteps">Mans i passes</string>
+    <string name="pref_title_support_voip_calls">Activa les trucades de VoIP</string>
+    <string name="fw_upgrade_notice_amazfitcor2">Sou a punt d\'instal·lar el microprogramari %s en el vostre Amazfit Cor 2.
+\n
+\nSi us plau, assegureu-vos d\'instal·lar el fitxer .fw, i després el fitxer .res. La vostra polsera es reiniciarà després d\'instal·lar el fitxer .fw.
+\n
+\nObservació: No cal que instal·leu el fitxer .res si és exactament el mateix que ja estava instal·lat.
+\n
+\nPROCEDIU SOTA LA VOSTRA PRÒPIA RESPONSABILITAT!
+\n
+\nAIXÒ NO HA ESTAT PROVAT ABANS. PROBABLEMENT CAL QUE INSTAL·LEU UN MICROPROGRAMARI BEATS_W SI EL NOM DEL VOSTRE APARELL ÉS \"Amazfit Band 2\"</string>
+    <string name="firmware_install_warning">ESTEU PROVANT D\'INSTAL·LAR UN MICROPROGRAMARI. CONTINUEU SOTA LA VOSTRA RESPONSABILITAT.
+\n
+\n
+\nAquest microprogramari és per a la revisió del maquinari: %s</string>
+    <string name="miband_pairing_using_dummy_userdata">No s\'han introduït dades vàlides. De moment es fan servir dades fictícies.</string>
+    <string name="miband_pairing_tap_hint">Quan la vostra Mi Band vibri i parpallegi, toqueu-la vàries vegades seguides.</string>
+    <string name="discovery_connected_devices_hint">Feu que el vostre aparell es pugui detectar. Els aparells que ara estan connectats probablement no seran detectats. Activeu la localització (per exemple, el GPS) a Android 6+. Desactiveu el Privacy Guard per al Gadgetbridge, perquè podria penjar-se i fer que el telèfon es reniciés. Si després d\'uns quants minuts no s\'ha trobat cap aparell, torneu-ho a provar després de reiniciar el telèfon.</string>
+    <string name="pref_title_dont_ack_transfer">No enviïs l\'ACK de les dades d\'activitats</string>
+    <string name="pref_summary_dont_ack_transfers">Si l\'arribada de les dades d\'activitats no és notificada a la polsera, aquestes dades no s\'eliminaran. Aquesta opció pot ser útil si feu servir el Gadgebridge també amb altres aplicacions.</string>
+    <string name="pref_summary_keep_data_on_device">Les dades d\'activitats de la Mi Band es guardaran fins i tot després de sincronitzar. Aquesta opció pot ser útil si feu servir el Gadgebridge també amb altres aplicacions.</string>
+    <string name="mi2_prefs_button_press_broadcast_summary">Messatge que s\'enviarà quan s\'hagi premut el botó el nombre de vegades establert</string>
+    <string name="mi2_prefs_button_press_count_match_delay_summary">Retard després d\'una acció de botó (el nombre és a l\'intent extra de button_id) o 0 per procedir immediatament</string>
+    <string name="pref_title_pebble_health_store_raw">Desa dades sense processar a la base de dades</string>
+    <string name="pref_summary_pebble_health_store_raw">Desa les dades \"tal qual\", tot augmentant l\'ús de la base de dades per tal de permetre possibles interpretacions més tard.</string>
+    <string name="action_db_management">Gestió de la base de dades</string>
+    <string name="title_activity_db_management">Gestió de la base de dades</string>
+    <string name="activity_db_management_import_export_explanation">Les operacions de base de dades fan servir el següent camí al vostre aparell.
+\nAquest camí és accessible des d\'altres aparells Android i des del vostre ordinador.
+\nQuan exporteu una base de dades, la trobareu aquí, i quan vulgueu importar una base de dades, heu de deixar els fitxers també aquí:</string>
+    <string name="activity_db_management_merge_old_title">Esborra la base de dades antiga</string>
+    <string name="dbmanagementactivvity_cannot_access_export_path">No es pot accedir al camí d\'exportació. Si us plau, contacteu els desenvolupadors.</string>
+    <string name="dbmanagementactivity_exported_to">S\'ha exportat a: %1$s</string>
+    <string name="dbmanagementactivity_error_exporting_db">Hi ha hagut un error en esborrar la base de dades: %1$s</string>
+    <string name="dbmanagementactivity_error_exporting_shared">Hi ha hagut un error en exportar la preferència: %1$s</string>
+    <string name="dbmanagementactivity_import_data_title">Voleu importar les dades\?</string>
+    <string name="dbmanagementactivity_overwrite_database_confirmation">De debò voleu sobreescriure la base de dades actual\? Totes les vostres dades actuals d\'activitats (si en teniu) es perdran.</string>
+    <string name="dbmanagementactivity_import_successful">S\'ha importat.</string>
+    <string name="dbmanagementactivity_error_importing_db">Hi ha hagut un error en importar la base de dades: %1$s</string>
+    <string name="dbmanagementactivity_error_importing_shared">Hi ha hagut un error en importar la preferència: %1$s</string>
+    <string name="dbmanagementactivity_delete_activity_data_title">Voleu esborrar les dades d\'activitats\?</string>
+    <string name="dbmanagementactivity_really_delete_entire_db">De debò voleu esborrar tota la base de dades\? Totes les vostres dades d\'activitats i tota la informació sobre els vostres aparells es perdran.</string>
+    <string name="dbmanagementactivity_database_successfully_deleted">S\'han esborrat les dades.</string>
+    <string name="dbmanagementactivity_db_deletion_failed">Ha fallat la supressió de la base de dades.</string>
+    <string name="dbmanagementactivity_delete_old_activity_db">Voleu esborrar la base de dades antiga d\'activitats\?</string>
+    <string name="dbmanagementactivity_delete_old_activitydb_confirmation">De debò voleu esborrar la base de dades antiga d\'activitats\? Les dades d\'activitats que no haguessin estat importades es perdran.</string>
+    <string name="dbmanagementactivity_old_activity_db_successfully_deleted">Les dades antigues d\'activitats s\'han esborrat.</string>
+    <string name="dbmanagementactivity_old_activity_db_deletion_failed">Ha fallat la supressió de la base de dades antiga d\'activitats.</string>
+    <string name="dbmanagementactivity_overwrite">Sobreescriu</string>
+    <string name="Cancel">Cancel·la</string>
+    <string name="Delete">Esborra</string>
+    <string name="title_activity_vibration">Vibració</string>
+    <string name="title_activity_pebble_pairing">Aparellament amb Pebble</string>
+    <string name="pebble_pairing_hint">Apareixerà un diàleg d\'aparellament al vostre aparell Android. Si no, cerqueu-lo entre les notificacions i accepteu la petició d\'aparellament. Després accepteu l\'aparellament també al Pebble.</string>
+    <string name="weather_notification_label">Assegureu-vos que aquesta aparença està activada en l\'aplicació de notificació del temps per obtenir informació del temps al vostre Pebble.
+\n
+\nAquí no cal configurar res.
+\n
+\nPodeu activar l\'aplicació del temps del sistema del vostre Pebble des de la gestió d\'aplicacions.
+\n
+\nLes caràtules compatibles mostraran el temps automàticament.</string>
+    <string name="pref_title_setup_bt_pairing">Activa l\'aparellament per Bluetooth</string>
+    <string name="pref_summary_setup_bt_pairing">Desactiveu això si teniu problemes de connexió</string>
+    <string name="unit_metric">Sistema mètric</string>
+    <string name="unit_imperial">Sistema imperial</string>
+    <string name="timeformat_24h">24h</string>
+    <string name="timeformat_am_pm">AM/PM</string>
+    <string name="pref_screen_notification_profile_alarm_clock">Despertador</string>
+    <string name="activity_web_view">Activitat Web View</string>
+    <string name="StringUtils_sender">(%1$s)</string>
+    <string name="find_device_you_found_it">L\'heu trobat!</string>
+    <string name="miband2_prefs_timeformat">Mi2: format d\'hora</string>
+    <string name="mi2_fw_installhandler_fw53_hint">Heu d\'instal·lar la versió %1$s abans d\'instal·lar aquest microprogramari!</string>
+    <string name="mi2_enable_text_notifications">Notifications de text</string>
+    <string name="mi2_enable_text_notifications_summary">Necessita tenir instal·lats el microrprogramari &gt;= 1.10.1.28 i Mili_pro.ft*.</string>
+    <string name="off">Desactivat</string>
+    <string name="mi2_dnd_off">Desactivat</string>
+    <string name="mi2_dnd_automatic">Automàtic (detecció de son)</string>
+    <string name="mi2_dnd_scheduled">Programat (interval de temps)</string>
+    <string name="discovery_attempting_to_pair">S\'està intentant aparellar amb %1$s</string>
+    <string name="discovery_bonding_failed_immediately">El vincle amb %1$s ha fallat immediatament.</string>
+    <string name="discovery_trying_to_connect_to">S\'està intentant connectar amb: %1$s</string>
+    <string name="discovery_enable_bluetooth">Activa el Bluetooth per detectar aparells.</string>
+    <string name="discovery_successfully_bonded">Enllaçat amb %1$s.</string>
+    <string name="discovery_pair_title">Voleu aparellar amb %1$s\?</string>
+    <string name="discovery_pair_question">Seleccioneu \"Aparella\" per aparellar els vostres aparells. Si no funciona, torneu-ho a provar sense aparellar.</string>
+    <string name="discovery_yes_pair">Aparella</string>
+    <string name="discovery_dont_pair">No aparellis</string>
+    <string name="_pebble_watch_open_on_phone">Obre a l\'aparell Android</string>
+    <string name="_pebble_watch_mute">Silencia</string>
+    <string name="_pebble_watch_reply">Respon</string>
+    <string name="kind_firmware">Microprogramari</string>
+    <string name="kind_invalid">Les dades no són vàlides</string>
+    <string name="kind_font">Tipus de lletra</string>
+    <string name="kind_gps">Microprogramari del GPS</string>
+    <string name="kind_gps_almanac">Almanac GPS</string>
+    <string name="kind_gps_cep">Correcció d\'errors del GPS</string>
+    <string name="kind_resources">Recursos</string>
+    <string name="kind_watchface">Caràtula</string>
+    <string name="devicetype_unknown">Aparell desconegut</string>
+    <string name="devicetype_test">Aparell de prova</string>
+    <string name="devicetype_pebble">Pebble</string>
+    <string name="devicetype_miband">Mi Band</string>
+    <string name="devicetype_miband2">Mi Band 2</string>
+    <string name="devicetype_amazfit_bip">Amazfit Bip</string>
+    <string name="devicetype_amazfit_cor">Amazfit Cor</string>
+    <string name="devicetype_vibratissimo">Vibratissimo</string>
+    <string name="devicetype_liveview">LiveView</string>
+    <string name="devicetype_hplus">HPlus</string>
+    <string name="devicetype_makibes_f68">Makibes F68</string>
+    <string name="devicetype_exrizu_k8">Exrizu K8</string>
+    <string name="devicetype_no1_f1">No.1 F1</string>
+    <string name="devicetype_teclast_h30">Teclast H30</string>
+    <string name="choose_auto_export_location">Tria la ubicació de l\'exportació</string>
+    <string name="notification_channel_name">Notificacions del Gadgetbridge</string>
+    <string name="devicetype_xwatch">XWatch</string>
+    <string name="on">Activat</string>
+    <string name="controlcenter_start_activity_tracks">Les vostres pistes d\'activitat</string>
+    <string name="activity_type_not_measured">No mesurat</string>
+    <string name="activity_type_activity">Activitat</string>
+    <string name="activity_type_light_sleep">Son lleuger</string>
+    <string name="activity_type_deep_sleep">Son profund</string>
+    <string name="activity_type_not_worn">Aparell no usat</string>
+    <string name="activity_type_running">Córrer</string>
+    <string name="activity_type_walking">Caminar</string>
+    <string name="activity_type_swimming">Nedar</string>
+    <string name="activity_type_unknown">Activitat desconeguda</string>
+    <string name="activity_summaries">Activitats</string>
+    <string name="activity_type_biking">Ciclisme</string>
+    <string name="activity_type_treadmill">Cinta de córrer</string>
+    <string name="select_all">Selecciona-ho tot</string>
+    <string name="share">Comparteix</string>
+    <string name="reset_index">Reinicialitza la dada d\'extracció</string>
+    <string name="menuitem_status">Estat</string>
+    <string name="menuitem_activity">Activitat</string>
+    <string name="menuitem_weather">El Temps</string>
+    <string name="menuitem_alarm">Alarma</string>
+    <string name="menuitem_timer">Temporitzador</string>
+    <string name="menuitem_compass">Brúixola</string>
+    <string name="menuitem_settings">Configuració</string>
+    <string name="menuitem_alipay">Alipay</string>
+    <string name="menuitem_shortcut_alipay">Alipay (drecera)</string>
+    <string name="menuitem_shortcut_weather">El temps (drecera)</string>
+    <string name="devicetype_q8">Q8</string>
+    <string name="devicetype_miband3">Mi Band 3</string>
+    <string name="pref_auto_fetch">Recull automàticament les dades d\'activitats</string>
+    <string name="pref_auto_fetch_summary">Es recullen dades quan es bloqueja la pantalla. Només funciona si hi ha un sistema de bloqueig establert!</string>
+    <string name="pref_auto_fetch_limit_fetches">Temps mínim entre extraccions</string>
+    <string name="pref_auto_fetch_limit_fetches_summary">Extraccions cada %d minuts</string>
+    <string name="devicetype_mykronoz_zetime">MyKronoz ZeTime</string>
+    <string name="russian">Rus</string>
+    <string name="horizontal">Horitzontal</string>
+    <string name="vertical">Vertical</string>
+    <string name="devicetype_id115">ID115</string>
+    <string name="preferences_amazfitcor_settings">Configuració d\'Amazfit Cor</string>s
+    <string name="menuitem_notifications">Notificacions</string>
+    <string name="preferences_miband2_settings">Configuració de Mi Band 2</string>
+    <string name="preferences_miband3_settings">Configuració de Mi Band 3</string>
+    <string name="menuitem_more">Més</string>
+    <string name="menuitem_music">Música</string>
+    <string name="watch9_pairing_tap_hint">Quan el vostre aparell vibri, sacsegeu-lo o premeu-ne el botó.</string>
+    <string name="devicetype_watch9">Watch 9</string>
+    <string name="watch9_time_minutes">Minuts:</string>
+    <string name="watch9_time_hours">Hores:</string>
+    <string name="watch9_time_seconds">Segons:</string>
+    <string name="watch9_calibration_hint">Establiu l\'hora que l\'aparell us mostra ara mateix.</string>
+    <string name="watch9_calibration_button">Calibra</string>
+    <string name="title_activity_watch9_pairing">Aparellament del Watch 9</string>
+    <string name="title_activity_watch9_calibration">Calibratge del Watch 9</string>
+    <string name="mi3_prefs_band_screen_unlock">Desbloqueig de la pantalla de la polsera</string>
+    <string name="mi3_prefs_band_screen_unlock_summary">Passa el dit cap amunt per desbloquejar la pantalla de la polsera</string>
+    <string name="german">Alemany</string>
+    <string name="italian">Italià</string>
+    <string name="french">Francès</string>
+    <string name="polish">Polonès</string>
+    <string name="korean">Coreà</string>
+    <string name="japanese">Japonès</string>
+    <string name="you_slept">Heu dormit de %1$s a %2$s</string>
+    <string name="you_did_not_sleep">No heu dormit</string>
+    <string name="norwegian_bokmal">Noruec bokmål</string>
+    <string name="no_limit">Sense límit</string>
+    <string name="seconds_5">5 segons</string>
+    <string name="seconds_10">10 segons</string>
+    <string name="seconds_20">20 segons</string>
+    <string name="seconds_30">30 segons</string>
+    <string name="minutes_1">1 minut</string>
+    <string name="minutes_5">5 minuts</string>
+    <string name="minutes_10">10 minuts</string>
+    <string name="minutes_30">30 minuts</string>
+    <string name="mi3_prefs_night_mode">Mode nocturn</string>
+    <string name="mi3_prefs_night_mode_summary">Rebaixa la brillantor de la pantalla de la polsera automàticament a la nit</string>
+    <string name="mi3_night_mode_sunset">Al capvespre</string>
+    <string name="ok">D\'acord</string>
+    <string name="share_log">Comparteix el registre</string>
+    <string name="share_log_warning">Si us plau, tingueu en compte que els fitxers de registre del Gadgetbridge poden contenir molta informació personal, incloent-hi, entre d\'altres, dades relacionades amb la salut, identificadors únics (com ara adreces MAC), preferències musicals, etc. Considereu editar el fitxer i suprimir aquesta informació abans d\'enviar-lo a un informe públic d\'error.</string>
+    <string name="warning">Atenció!</string>
+    <string name="devicetype_roidmi">Roidmi</string>
+    <string name="devicetype_roidmi3">Roidmi 3</string>
+    <string name="preferences_led_color">Color del LED</string>
+    <string name="preferences_fm_frequency">Freqüència de FM</string>
+    <string name="pref_invalid_frequency_title">La freqüència no és vàlida</string>
+    <string name="pref_invalid_frequency_message">Si us plau, introduïu una freqüència entre 87,5 i 108,0</string>
+    <string name="activity_prefs_charts">Configuració dels gràfics</string>
+    <string name="activity_prefs_chart_max_heart_rate">Ritme cardíac màxim</string>
+    <string name="activity_prefs_chart_min_heart_rate">Ritme cardíac mínim</string>
+    <string name="notif_battery_low">%1$s nivell de bateria baix</string>
+    <string name="notif_battery_low_extended">%1$s nivell de bateria baix: %2$s</string>
+    <string name="pref_title_contextual_arabic">Àrab contextual</string>
+    <string name="pref_summary_contextual_arabic">Activeu això per a compatibilitat amb l\'àrab contextual</string>
+    <string name="preferences_rtl_settings">Compatibilitat amb escriptura de dreta a esquerra</string>
+    <string name="language_and_region_prefs">Configuració de llengua i regió</string>
+    <string name="lack_of_sleep">Manca de son: %1$s</string>
+    <string name="overslept">Son de més: %1$s</string>
+    <string name="lack_of_step">Manca de passes: %1$d</string>
+    <string name="overstep">Passes de més: %1$d</string>
+    <string name="no_data">No hi ha dades</string>
+    <string name="live_activity_max_heart_rate">Ritme cardíac actual / màxim: %1$d / %2$d</string>
+    <string name="devicetype_casiogb6900">Casio GB-6900</string>
+    <string name="title_activity_notification_filter">Filtre de notificacions</string>
+    <string name="toast_app_must_not_be_blacklisted">L\'aplicació no ha d\'estar bloquejada per poder-la configurar</string>
+    <string name="edittext_notification_filter_words_hint">Introduïu les paraules desitjades, cadascuna en una línia nova</string>
+    <string name="toast_notification_filter_saved_successfully">S\'ha desat el filtre de notificacions</string>
+    <string name="filter_mode_none">No filtris</string>
+    <string name="filter_mode_whitelist">Mostra quan es contenen les paraules</string>
+    <string name="filter_mode_blacklist">Bloca quan es contenen les paraules</string>
+    <string name="filter_submode_at_least_one">Almenys una de les paraules</string>
+    <string name="filter_submode_all">Totes les paraules</string>
+    <string name="toast_notification_filter_words_empty_hint">Si us plau, introduïu com a mínim una paraula</string>
+    <string name="filter_mode">Mode de filtratge</string>
+    <string name="mode_configuration">Configuració del mode</string>
+    <string name="save_configuration">Desa la configuració</string>
+    <string name="appwidget_not_connected">No està connectat, no s\'ha establert l\'alarma.</string>
+    <string name="activity_type_exercise">Exercici</string>
+    <string name="prefs_disconnect_notification">Notificació de desconnexió</string>
+    <string name="zetime_activity_tracking">Seguiment d\'activitats</string>
+    <string name="zetime_activity_tracking_summary">Activeu aquesta opció per comptar les vostres passes i altres activitats.</string>
+    <string name="zetime_handmove_display">Moviment de la mà</string>
+    <string name="zetime_handmove_display_summary">Moveu el canell per activar o desactivar la pantalla.</string>
+    <string name="zetime_calories_type">Tipus de calories</string>
+    <string name="zetime_calories_type_active">Només les calories cremades de forma activa</string>
+    <string name="zetime_calories_type_all">Calories cremades de forma activa i en repòs</string>
+    <string name="zetime_time_format">Format d\'hora</string>
+    <string name="zetime_time_format_24h">24h</string>
+    <string name="zetime_time_format_12h">12h</string>
+    <string name="zetime_date_format">Format de data</string>
+    <string name="zetime_date_format_1">AA/MM/DD</string>
+    <string name="zetime_date_format_2">DD/MM/AA</string>
+    <string name="zetime_date_format_3">MM/DD/AA</string>
+    <string name="zetime_prefs_inactivity_repetitions">Repeticions</string>
+    <string name="zetime_prefs_inactivity_mo">Dilluns</string>
+    <string name="zetime_prefs_inactivity_tu">Dimarts</string>
+    <string name="zetime_prefs_inactivity_we">Dimecres</string>
+    <string name="zetime_prefs_inactivity_th">Dijous</string>
+    <string name="zetime_prefs_inactivity_fr">Divendres</string>
+    <string name="zetime_prefs_inactivity_sa">Dissabte</string>
+    <string name="zetime_prefs_inactivity_su">Diumenge</string>
+    <string name="zetime_title_alarm_signaling">Defineix el tipus de senyal per a l\'alarma</string>
+    <string name="zetime_signaling_none">Silenciós</string>
+    <string name="zetime_signaling_vibrate">Vibració contínua</string>
+    <string name="zetime_signaling_beep">Timbre continu</string>
+    <string name="zetime_signaling_vibrate_beep">Vibració i timbre continus</string>
+    <string name="zetime_signaling_vibrate_once">Vibra una vegada</string>
+    <string name="zetime_signaling_vibrate_twice">Vibra dues vegades</string>
+    <string name="zetime_signaling_beep_once">Fes sonar un timbre una vegada</string>
+    <string name="zetime_signaling_beep_twice">Fes sonar un timbre dues vegades</string>
+    <string name="zetime_signaling_vibrate_beep_once">Vibra i fes sonar un timbre una vegada</string>
+    <string name="pref_screen_notification_profile_missed_call">Notificació de trucada perduda</string>
+    <string name="pref_screen_notification_profile_calendar">Notificació de calendari</string>
+    <string name="pref_screen_notification_profile_inactivity">Notificació d\'inactivitat</string>
+    <string name="pref_screen_notification_profile_low_power">Avís de bateria baixa</string>
+    <string name="pref_screen_notification_profile_anti_loss">Avís anti-pèrdua</string>
+    <string name="interval_fifteen_minutes">cada 15 minuts</string>
+    <string name="interval_forty_five_minutes">cada 45 minuts</string>
+    <string name="activity_prefs_calories_burnt">Objectiu diari: calories cremades</string>
+    <string name="activity_prefs_distance_meters">Objectiu diari: distància en metres</string>
+    <string name="activity_prefs_activetime_minutes">Objectiu diari: temps d\'activitat en minuts</string>
+    <string name="devicetype_miscale2">Mi Scale 2</string>
+    <string name="title_activity_device_specific_settings">Configuració específica de l\'aparell</string>
+    <string name="pref_title_authkey">Clau d\'autenticació</string>
+    <string name="pref_summary_authkey">Canvia la clau d\'autenticació en tots els aparells Android des des quals et vulguis connectar. La clau anterior per defecte per a tots els aparells és 0123456789@ABCDE</string>
+    <string name="devicetype_bfh16">BFH-16</string>
+    <string name="dutch">Neerlandès</string>
+    <string name="turkish">Turc</string>
+    <string name="ukrainian">Ucraïnès</string>
+    <string name="arabic">Àrab</string>
+    <string name="indonesian">Indonesi</string>
+    <string name="thai">Tailandès</string>
+    <string name="vietnamese">Vietnamita</string>
+    <string name="portuguese">Portuguès</string>
+    <string name="devicetype_amazfit_cor2">Amazfit Cor 2</string>
+    <string name="devicetype_miband4">Mi Band 4</string>
+</resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -13,6 +13,7 @@
 
     <string-array name="pref_language_options">
         <item name="default">System Default</item>
+        <item name="ca">Català</item>
         <item name="cs">Čeština</item>
         <item name="de">Deutsch</item>
         <item name="en">English</item>
@@ -31,6 +32,7 @@
 
     <string-array name="pref_language_values">
         <item>default</item>
+        <item>ca</item>
         <item>cs</item>
         <item>de</item>
         <item>en</item>


### PR DESCRIPTION
Updates the Catalan strings file and adds the Catalan language option in the settings.

- [x] Translated all strings on Weblate
- [x] Reviewed all existing strings for coherence and created a repo-specific glossary on the Weblate project
- [x] Based on existing guidelines (Softcatalà), glossaries (Termcat) and translation memories (Microsoft)
- [x] App manually tested