### PR TITLE
ZeTime BUGFIX: Really fix the timestamps now for everyone, everywhere.

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/zetime/ZeTimeDeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/zetime/ZeTimeDeviceSupport.java
@@ -76,7 +76,7 @@ public class ZeTimeDeviceSupport extends AbstractBTLEDeviceSupport {
     private final GBDeviceEventBatteryInfo batteryCmd = new GBDeviceEventBatteryInfo();
     private final GBDeviceEventVersionInfo versionCmd = new GBDeviceEventVersionInfo();
     private final GBDeviceEventMusicControl musicCmd = new GBDeviceEventMusicControl();
-    private final int sevenHourOffset = 25200;
+    private final int eightHourOffset = 28800;
     private byte[] lastMsg;
     private byte msgPart;
     private int availableSleepData;
@@ -1171,8 +1171,10 @@ public class ZeTimeDeviceSupport extends AbstractBTLEDeviceSupport {
     private void handleStepsData(byte[] msg)
     {
         ZeTimeActivitySample sample = new ZeTimeActivitySample();
+        Calendar now = GregorianCalendar.getInstance();
         int timestamp = (msg[10] << 24)&0xff000000 | (msg[9] << 16)&0xff0000 | (msg[8] << 8)&0xff00 | (msg[7]&0xff);
-        timestamp += sevenHourOffset; // the timestamp from the watch has an offset of seven hours, do not know why...
+        timestamp += eightHourOffset; // the timestamp from the watch has an offset of eight hours, do not know why...
+        timestamp -= ((now.get(Calendar.ZONE_OFFSET)/1000) + (now.get(Calendar.DST_OFFSET)/1000));  // TimeZone hour + daylight saving
         sample.setTimestamp(timestamp);
         sample.setSteps((msg[14] << 24)&0xff000000 | (msg[13] << 16)&0xff0000 | (msg[12] << 8)&0xff00 | (msg[11]&0xff));
         sample.setCaloriesBurnt((msg[18] << 24)&0xff000000 | (msg[17] << 16)&0xff0000 | (msg[16] << 8)&0xff00 | (msg[15]&0xff));
@@ -1217,8 +1219,10 @@ public class ZeTimeDeviceSupport extends AbstractBTLEDeviceSupport {
     private void handleSleepData(byte[] msg)
     {
         ZeTimeActivitySample sample = new ZeTimeActivitySample();
+        Calendar now = GregorianCalendar.getInstance();
         int timestamp = (msg[10] << 24)&0xff000000 | (msg[9] << 16)&0xff0000 | (msg[8] << 8)&0xff00 | (msg[7]&0xff);
-        timestamp += sevenHourOffset; // the timestamp from the watch has an offset of seven hours, do not know why...
+        timestamp += eightHourOffset; // the timestamp from the watch has an offset of eight hours, do not know why...
+        timestamp -= ((now.get(Calendar.ZONE_OFFSET)/1000) + (now.get(Calendar.DST_OFFSET)/1000));  // TimeZone hour + daylight saving
         sample.setTimestamp(timestamp);
         if(msg[11] == 0) {
             sample.setRawKind(ActivityKind.TYPE_DEEP_SLEEP);
@@ -1260,8 +1264,10 @@ public class ZeTimeDeviceSupport extends AbstractBTLEDeviceSupport {
     private void handleHeartRateData(byte[] msg)
     {
         ZeTimeActivitySample sample = new ZeTimeActivitySample();
+        Calendar now = GregorianCalendar.getInstance();
         int timestamp = (msg[10] << 24)&0xff000000 | (msg[9] << 16)&0xff0000 | (msg[8] << 8)&0xff00 | (msg[7]&0xff);
-        timestamp += sevenHourOffset; // the timestamp from the watch has an offset of seven hours, do not know why...
+        timestamp += eightHourOffset; // the timestamp from the watch has an offset of eight hours, do not know why...
+        timestamp -= ((now.get(Calendar.ZONE_OFFSET)/1000) + (now.get(Calendar.DST_OFFSET)/1000));  // TimeZone hour + daylight saving
         sample.setHeartRate(msg[11]);
         sample.setTimestamp(timestamp);
 
@@ -1278,10 +1284,11 @@ public class ZeTimeDeviceSupport extends AbstractBTLEDeviceSupport {
         progressHeartRate = (msg[5]&0xff) | ((msg[6] << 8)&0xff00);
         GB.updateTransferNotification(null, getContext().getString(R.string.busy_task_fetch_activity_data), true, (int) (progressHeartRate *100 / availableHeartRateData), getContext());
 
-        if(((msg[4] << 8)&0xff00 | (msg[3]&0xff)) == 0xe) // if the message is longer than 0x7, than it has to measurements (payload = 0xe)
+        if(((msg[4] << 8)&0xff00 | (msg[3]&0xff)) == 0xe) // if the message is longer than 0x7, than it has two measurements (payload = 0xe)
         {
             timestamp = (msg[17] << 24)&0xff000000 | (msg[16] << 16)&0xff0000 | (msg[15] << 8)&0xff00 | (msg[14]&0xff);
-            timestamp += sevenHourOffset; // the timestamp from the watch has an offset of seven hours, do not know why...
+            timestamp += eightHourOffset; // the timestamp from the watch has an offset of eight hours, do not know why...
+            timestamp -= ((now.get(Calendar.ZONE_OFFSET)/1000) + (now.get(Calendar.DST_OFFSET)/1000));  // TimeZone hour + daylight saving
             sample.setHeartRate(msg[18]);
             sample.setTimestamp(timestamp);
 


### PR DESCRIPTION
calculate the correct UTC of different timezones and daylight savings.