### PR TITLE
NEW FEATURE: Add preference to turn your clock forward or backward

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/SettingsActivity.java
@@ -198,6 +198,24 @@ public class SettingsActivity extends AbstractSettingsActivity {
 
         });
 
+        pref = findPreference("datetime_turn_clocks_forward");
+        pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newVal) {
+                try {
+                    GBApplication.deviceService().onSetTime();
+                } catch (Exception ex) {
+                    GB.toast(getApplicationContext(),
+                            "Error setting new time: " + ex.getLocalizedMessage(),
+                            Toast.LENGTH_LONG,
+                            GB.ERROR,
+                            ex);
+                }
+                return true;
+            }
+
+        });
+
         final Preference unit = findPreference(PREF_MEASUREMENT_SYSTEM);
         unit.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/casiogb6900/CasioGB6900DeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/casiogb6900/CasioGB6900DeviceSupport.java
@@ -54,6 +54,7 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.GattService;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.ServerTransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.devices.casiogb6900.operations.InitOperation;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.StringUtils;
 
@@ -225,7 +226,7 @@ public class CasioGB6900DeviceSupport extends AbstractBTLEDeviceSupport {
 
     private void writeCasioCurrentTime(TransactionBuilder builder) {
         byte[] arr = new byte[10];
-        Calendar cal = Calendar.getInstance();
+        Calendar cal = DateTimeUtils.getCalendarTurnClockForward();
 
         int year = cal.get(Calendar.YEAR);
         arr[0] = (byte)((year >>> 0) & 0xff);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -59,6 +59,7 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSuppo
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfo;
 import nodomain.freeyourgadget.gadgetbridge.util.AlarmUtils;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.StringUtils;
 
@@ -191,7 +192,8 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
     }
 
     private HPlusSupport setCurrentDate(TransactionBuilder transaction) {
-        Calendar c = GregorianCalendar.getInstance();
+        Calendar c = DateTimeUtils.getCalendarTurnClockForward();
+
         int year = c.get(Calendar.YEAR);
         int month = c.get(Calendar.MONTH);
         int day = c.get(Calendar.DAY_OF_MONTH);
@@ -208,7 +210,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
     }
 
     private HPlusSupport setCurrentTime(TransactionBuilder transaction) {
-        Calendar c = GregorianCalendar.getInstance();
+        Calendar c = DateTimeUtils.getCalendarTurnClockForward();
 
         transaction.write(ctrlCharacteristic, new byte[]{
                 HPlusConstants.CMD_SET_TIME,

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/HuamiSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/HuamiSupport.java
@@ -120,6 +120,7 @@ import nodomain.freeyourgadget.gadgetbridge.service.devices.miband.NotificationS
 import nodomain.freeyourgadget.gadgetbridge.service.devices.miband.RealtimeSamplesSupport;
 import nodomain.freeyourgadget.gadgetbridge.service.serial.GBDeviceProtocol;
 import nodomain.freeyourgadget.gadgetbridge.util.AlarmUtils;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.DeviceHelper;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.NotificationUtils;
@@ -256,7 +257,7 @@ public class HuamiSupport extends AbstractBTLEDeviceSupport {
     }
 
     public HuamiSupport setCurrentTimeWithService(TransactionBuilder builder) {
-        GregorianCalendar now = BLETypeConversions.createCalendar();
+        Calendar now = DateTimeUtils.getCalendarTurnClockForward();
         byte[] bytes = getTimeBytes(now, TimeUnit.SECONDS);
         builder.write(getCharacteristic(GattCharacteristic.UUID_CHARACTERISTIC_CURRENT_TIME), bytes);
         return this;

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/id115/ID115Support.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/id115/ID115Support.java
@@ -45,6 +45,7 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSuppo
 import nodomain.freeyourgadget.gadgetbridge.service.btle.GattService;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.actions.SetDeviceStateAction;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 
 public class ID115Support extends AbstractBTLEDeviceSupport {
     private static final Logger LOG = LoggerFactory.getLogger(ID115Support.class);
@@ -269,7 +270,7 @@ public class ID115Support extends AbstractBTLEDeviceSupport {
     }
 
     ID115Support setTime(TransactionBuilder builder) {
-        Calendar c = Calendar.getInstance(TimeZone.getDefault());
+        Calendar c = DateTimeUtils.getCalendarTurnClockForward();
 
         int day = c.get(Calendar.DAY_OF_WEEK);
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/jyou/BFH16DeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/jyou/BFH16DeviceSupport.java
@@ -81,6 +81,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.WeatherSpec;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSupport;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.util.AlarmUtils;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.StringUtils;
 
@@ -546,7 +547,8 @@ public class BFH16DeviceSupport extends AbstractBTLEDeviceSupport {
 
     //working
     private void syncDateAndTime(TransactionBuilder builder) {
-        Calendar cal = Calendar.getInstance();
+        Calendar cal = DateTimeUtils.getCalendarTurnClockForward();
+
         String strYear = String.valueOf(cal.get(Calendar.YEAR));
         byte year1 = (byte)Integer.parseInt(strYear.substring(0, 2));
         byte year2 = (byte)Integer.parseInt(strYear.substring(2, 4));

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/jyou/TeclastH30Support.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/jyou/TeclastH30Support.java
@@ -47,6 +47,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.WeatherSpec;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSupport;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.util.AlarmUtils;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.StringUtils;
 
@@ -126,7 +127,8 @@ public class TeclastH30Support extends AbstractBTLEDeviceSupport {
     }
 
     private void syncDateAndTime(TransactionBuilder builder) {
-        Calendar cal = Calendar.getInstance();
+        Calendar cal = DateTimeUtils.getCalendarTurnClockForward();
+
         String strYear = String.valueOf(cal.get(Calendar.YEAR));
         byte year1 = (byte)Integer.parseInt(strYear.substring(0, 2));
         byte year2 = (byte)Integer.parseInt(strYear.substring(2, 4));

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband/MiBandSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/miband/MiBandSupport.java
@@ -622,7 +622,7 @@ public class MiBandSupport extends AbstractBTLEDeviceSupport {
      * @param builder
      */
     private MiBandSupport setCurrentTime(TransactionBuilder builder) {
-        Calendar now = GregorianCalendar.getInstance();
+        Calendar now = DateTimeUtils.getCalendarTurnClockForward();
         Date date = now.getTime();
         LOG.info("Sending current time to Mi Band: " + DateTimeUtils.formatDate(date) + " (" + date.toGMTString() + ")");
         byte[] nowBytes = MiBandDateConverter.calendarToRawBytes(now, gbDevice.getAddress());

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/no1f1/No1F1Support.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/no1f1/No1F1Support.java
@@ -59,6 +59,7 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSuppo
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.actions.SetDeviceBusyAction;
 import nodomain.freeyourgadget.gadgetbridge.util.AlarmUtils;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 
 import static org.apache.commons.lang3.math.NumberUtils.min;
@@ -395,7 +396,7 @@ public class No1F1Support extends AbstractBTLEDeviceSupport {
     }
 
     private void setTime(TransactionBuilder transaction) {
-        Calendar c = GregorianCalendar.getInstance();
+        Calendar c = DateTimeUtils.getCalendarTurnClockForward();
         byte[] datetimeBytes = new byte[]{
                 No1F1Constants.CMD_DATETIME,
                 (byte) ((c.get(Calendar.YEAR) / 256) & 0xff),

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/watch9/Watch9DeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/watch9/Watch9DeviceSupport.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 
 import androidx.annotation.IntRange;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventBatteryInfo;
 import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventVersionInfo;
 import nodomain.freeyourgadget.gadgetbridge.devices.watch9.Watch9Constants;
@@ -60,6 +61,7 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.actions.SetDeviceStateA
 import nodomain.freeyourgadget.gadgetbridge.service.devices.watch9.operations.InitOperation;
 import nodomain.freeyourgadget.gadgetbridge.util.AlarmUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.ArrayUtils;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 
 public class Watch9DeviceSupport extends AbstractBTLEDeviceSupport {
 
@@ -236,7 +238,7 @@ public class Watch9DeviceSupport extends AbstractBTLEDeviceSupport {
     }
 
     private void handleTime(byte[] time) {
-        GregorianCalendar now = BLETypeConversions.createCalendar();
+        Calendar now = DateTimeUtils.getCalendarTurnClockForward();
         GregorianCalendar nowDevice = BLETypeConversions.createCalendar();
         int year = (nowDevice.get(Calendar.YEAR) / 100) * 100 + Conversion.fromBcd8(time[8]);
         nowDevice.set(year,
@@ -250,7 +252,7 @@ public class Watch9DeviceSupport extends AbstractBTLEDeviceSupport {
         long timeDiff = (Math.abs(now.getTimeInMillis() - nowDevice.getTimeInMillis())) / 1000;
         if (10 < timeDiff && timeDiff < 120) {
             enableCalibration(true);
-            setTime(BLETypeConversions.createCalendar());
+            setTime(DateTimeUtils.getCalendarTurnClockForward());
             enableCalibration(false);
         }
     }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/xwatch/XWatchSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/xwatch/XWatchSupport.java
@@ -59,6 +59,7 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSuppo
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.actions.SetDeviceStateAction;
 import nodomain.freeyourgadget.gadgetbridge.service.devices.miband.DeviceInfo;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 
 public class XWatchSupport extends AbstractBTLEDeviceSupport {
@@ -134,7 +135,7 @@ public class XWatchSupport extends AbstractBTLEDeviceSupport {
         LOG.debug("Sending current date to the XWatch");
         BluetoothGattCharacteristic deviceData = getCharacteristic(XWatchService.UUID_WRITE);
 
-        String time = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
+        String time = new SimpleDateFormat("yyyyMMddHHmmss").format(DateTimeUtils.todayTurnClockForward());
         String y = time.substring(2, 4);
         String M = time.substring(4, 6);
         String d = time.substring(6, 8);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/zetime/ZeTimeDeviceSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/zetime/ZeTimeDeviceSupport.java
@@ -64,6 +64,7 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.GattService;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.actions.SetDeviceStateAction;
 import nodomain.freeyourgadget.gadgetbridge.util.AlarmUtils;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
 
@@ -1439,7 +1440,8 @@ public class ZeTimeDeviceSupport extends AbstractBTLEDeviceSupport {
 
     private void synchronizeTime(TransactionBuilder builder)
     {
-        Calendar now = GregorianCalendar.getInstance();
+        Calendar now = DateTimeUtils.getCalendarTurnClockForward();
+
         byte[] timeSync = new byte[]{ZeTimeConstants.CMD_PREAMBLE,
                 ZeTimeConstants.CMD_DATE_TIME,
                 ZeTimeConstants.CMD_SEND,

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/DateTimeUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/DateTimeUtils.java
@@ -153,4 +153,29 @@ public class DateTimeUtils {
     public static String minutesToHHMM(int minutes) {
         return String.format(Locale.US, "%d:%02d", minutes / 60, minutes % 60); // no I do not want to use durationformatter :P
     }
+
+    public static Date todayTurnClockForward() {
+        Calendar now = getCalendarTurnClockForward();
+        return now.getTime();
+    }
+
+    public static Calendar getCalendarTurnClockForward() {
+        Calendar now = GregorianCalendar.getInstance();
+        // we will now check if the user likes to turn theirs clock forward or backward
+        // get the time entered on the preferences
+        int minutesToTurnClockForward = GBApplication.getPrefs().getInt("datetime_turn_clocks_forward", 0);
+        if(minutesToTurnClockForward > 10)
+        {   // check if the time is greater than 10 minutes forward; this could be changed to any value
+            minutesToTurnClockForward = 10;
+        } else if(minutesToTurnClockForward < -10)
+        {   // check if the time is greater than 10 minutes backward; this could be changed to any value
+            minutesToTurnClockForward = -10;
+        }
+        if(minutesToTurnClockForward != 0) { // if a value is given turn the actual clock time forwards or backwards
+            long timenow = now.getTimeInMillis(); // get the actual time in milli seconds
+            timenow += minutesToTurnClockForward * 60000; // convert the given minutes to milli seconds and add this to the actual time in milli seconds
+            now.setTimeInMillis(timenow); // set the "new time"
+        }
+        return now;
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="pref_header_datetime">Date and Time</string>
     <string name="pref_title_datetime_syctimeonconnect">Sync time</string>
     <string name="pref_summary_datetime_syctimeonconnect">Sync time to Gadgetbridge device when connecting, and when time or time zone changes on Android device</string>
+    <string name="pref_title_datetime_turn_clocks_forward">Turn your clock forward</string>
     <string name="pref_title_theme">Theme</string>
     <string name="pref_theme_light">Light</string>
     <string name="pref_theme_dark">Dark</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -190,6 +190,12 @@
             android:key="datetime_synconconnect"
             android:summary="@string/pref_summary_datetime_syctimeonconnect"
             android:title="@string/pref_title_datetime_syctimeonconnect" />
+        <EditTextPreference
+            android:inputType="numberSigned"
+            android:key="datetime_turn_clocks_forward"
+            android:maxLength="2"
+            android:defaultValue="0"
+            android:title="@string/pref_title_datetime_turn_clocks_forward" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="pref_key_notifications"


### PR DESCRIPTION
Some people might like this one...
Back in the days of "normal" clocks some liked to turn their clock forward by some minutes. They did it to be not too late for appointments or just to have some extra time.

So to get our gadgets to be ahead of our local time, I introduce a new preference and functions which gives back a calendar or date object, which is set according to that preference.
You can also set your gadget time behind your local time by some minutes, maybe someone likes this as well.

I have tested this with my ZeTime and it works as intended. But I do not own any other device to test the functionality thoroughly.