### PR TITLE
Formatted device information

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/impl/GBDevice.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/impl/GBDevice.java
@@ -498,7 +498,11 @@ public class GBDevice implements Parcelable {
     public List<ItemWithDetails> getDeviceInfos() {
         List<ItemWithDetails> result = new ArrayList<>();
         if (mDeviceInfos != null) {
-            result.addAll(mDeviceInfos);
+            for (ItemWithDetails deviceInfo : mDeviceInfos){
+                GenericItem item = new GenericItem(deviceInfo.getName() + ": ", deviceInfo.getDetails());
+                item.setIcon(deviceInfo.getIcon());
+                result.add(item);
+            }
         }
         if (mModel != null) {
             result.add(new GenericItem(DEVINFO_HW_VER, mModel));


### PR DESCRIPTION
Made proprietary Device information show up like "INFO: abc" instead of "INFOabc".

That problem could be avoided by using "INFO: " as the information key/name, but that seems to miss the point of a hashlist for me...