### PR TITLE
Fixed travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os: linux
+dist: trusty
+
 language: android
 
 jdk:


### PR DESCRIPTION
Reason why build is broken now is because recently travis switched workers to Ubuntu Xenial by default. But Trusty is still available so for now I simply specified it in the config file.
Ultimately it will be better to adapt to recent distribution because support period of Trusty is ended. I will try it later.