### PR TITLE
Use Rebble Store URI for Pebble watch app lookup

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/appmanager/AbstractAppManagerFragment.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/appmanager/AbstractAppManagerFragment.java
@@ -429,7 +429,7 @@ public abstract class AbstractAppManagerFragment extends Fragment {
                 startActivity(startIntent);
                 return true;
             case R.id.appmanager_app_openinstore:
-                String url = "https://pebble-appstore.romanport.com/" + ((selectedApp.getType() == GBDeviceApp.Type.WATCHFACE) ? "watchfaces" : "watchapps") + "/0/?query=" + selectedApp.getName();
+                String url = "https://apps.rebble.io/en_US/search/" + ((selectedApp.getType() == GBDeviceApp.Type.WATCHFACE) ? "watchfaces" : "watchapps") + "/1/?native=true&?query=" +  Uri.encode(selectedApp.getName());
                 Intent intent = new Intent(Intent.ACTION_VIEW);
                 intent.setData(Uri.parse(url));
                 startActivity(intent);


### PR DESCRIPTION
Uses the rebble store as lookup for apps and watchfaces. Android-store-app will also intercept this link.