### PR TITLE
Add dedicated charts section into Settings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="pref_title_general_autoreconnect">Reconnect automatically</string>
     <string name="pref_title_audio_player">Preferred Audioplayer</string>
     <string name="pref_default">Default</string>
+    <string name="pref_header_charts">Charts Settings</string>
     <string name="pref_title_charts_swipe">Enable left/right swipe in the charts activity</string>
     <string name="pref_header_datetime">Date and Time</string>
     <string name="pref_title_datetime_syctimeonconnect">Sync time</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -157,6 +157,9 @@
                 android:maxLength="3"
                 android:title="@string/activity_prefs_activetime_minutes" />
         </PreferenceScreen>
+ </PreferenceCategory>
+<PreferenceCategory
+        android:title="@string/pref_header_charts">
         <PreferenceScreen
             android:key="pref_charts"
             android:title="@string/activity_prefs_charts">


### PR DESCRIPTION
This is a small PR which adds "Charts Settings" preference category into the menu. The "Enable left/right swipe..." goes there. In the future, i would like to add "Show weekly average" into to this settings - preference category.

There is an existing "Chart settings", which contains Min/Max Heart Rate but i am not sure if they do belong to the "Charts Settings". I did include it, but please let me know if i should remove it.