### PR TITLE
#1598 Added type to intent when sharing

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/AndroidUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/AndroidUtils.java
@@ -224,7 +224,7 @@ public class AndroidUtils {
         Uri contentUri = FileProvider.getUriForFile(context,
                 context.getApplicationContext().getPackageName() + ".screenshot_provider", file);
         intent.setFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        intent.setData(contentUri);
+        intent.setDataAndType(contentUri,"application/gpx+xml");
         context.startActivity(intent);
     }
 }


### PR DESCRIPTION
This is addressing #1598 . I have also tried to fix the `ActivitySummariesActivity.shareMultiple` but haven't found a good combination yet. What was interesting is that when in `AndroidUtils.viewFile` i used 
```
intent.setData(...
intent.setType(...
```
it didn't work, but setting both at the same time:
```
intent.setDataAndType(contentUri,"application/gpx+xml");
```
worked. Perhaps `ActivitySummariesActivity.shareMultiple` has similar issue, not sure.

Anyways, this one is solved. Please review and merge. I tested it successfully here. Thank you
