### PR TITLE
Add optional 30days charts view

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/AbstractWeekChartFragment.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/AbstractWeekChartFragment.java
@@ -59,7 +59,7 @@ import nodomain.freeyourgadget.gadgetbridge.util.LimitedQueue;
 
 public abstract class AbstractWeekChartFragment extends AbstractChartFragment {
     protected static final Logger LOG = LoggerFactory.getLogger(AbstractWeekChartFragment.class);
-    protected final int TOTAL_DAYS = 7;
+    protected final int TOTAL_DAYS = getRangeDays();
 
     private Locale mLocale;
     private int mTargetValue = 0;
@@ -103,6 +103,17 @@ public abstract class AbstractWeekChartFragment extends AbstractChartFragment {
 //        mBalanceView.setText(getBalanceMessage(balance));
     }
 
+    private String getWeeksChartsLabel(Calendar day){
+        if (GBApplication.getPrefs().getBoolean("charts_range", true)) {
+            //month, show day date
+            return String.valueOf(day.get(Calendar.DAY_OF_MONTH));
+        }
+        else{
+            //week, show short day name
+            return day.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.SHORT, mLocale);
+        }
+    }
+
     private WeekChartsData<BarData> refreshWeekBeforeData(DBHandler db, BarChart barChart, Calendar day, GBDevice device) {
         day = (Calendar) day.clone(); // do not modify the caller's argument
         day.add(Calendar.DATE, -TOTAL_DAYS);
@@ -115,7 +126,7 @@ public abstract class AbstractWeekChartFragment extends AbstractChartFragment {
 
             balance += calculateBalance(amounts);
             entries.add(new BarEntry(counter, getTotalsForActivityAmounts(amounts)));
-            labels.add(day.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.SHORT, mLocale));
+            labels.add(getWeeksChartsLabel(day));
             day.add(Calendar.DATE, 1);
         }
 
@@ -335,6 +346,14 @@ public abstract class AbstractWeekChartFragment extends AbstractChartFragment {
         }
 
         return amounts;
+    }
+
+    private int getRangeDays(){
+        if (GBApplication.getPrefs().getBoolean("charts_range", true)) {
+            return 30;}
+        else{
+            return 7;
+        }
     }
 
     abstract String getAverage(float value);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/ChartsActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/ChartsActivity.java
@@ -338,6 +338,24 @@ public class ChartsActivity extends AbstractGBFragmentActivity implements Charts
             return 5;
         }
 
+        private String getSleepTitle() {
+            if (GBApplication.getPrefs().getBoolean("charts_range", true)) {
+                return getString(R.string.weeksleepchart_sleep_a_month);
+            }
+            else{
+                return getString(R.string.weeksleepchart_sleep_a_week);
+            }
+        }
+
+        public String getStepsTitle() {
+            if (GBApplication.getPrefs().getBoolean("charts_range", true)) {
+                return getString(R.string.weekstepschart_steps_a_month);
+            }
+            else{
+                return getString(R.string.weekstepschart_steps_a_week);
+            }
+        }
+
         @Override
         public CharSequence getPageTitle(int position) {
             switch (position) {
@@ -346,9 +364,9 @@ public class ChartsActivity extends AbstractGBFragmentActivity implements Charts
                 case 1:
                     return getString(R.string.sleepchart_your_sleep);
                 case 2:
-                    return getString(R.string.weeksleepchart_sleep_a_week);
+                    return getSleepTitle();
                 case 3:
-                    return getString(R.string.weekstepschart_steps_a_week);
+                    return getStepsTitle();
                 case 4:
                     return getString(R.string.stats_title);
                 case 5:

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/WeekSleepChartFragment.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/WeekSleepChartFragment.java
@@ -40,7 +40,12 @@ import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 public class WeekSleepChartFragment extends AbstractWeekChartFragment {
     @Override
     public String getTitle() {
-        return getString(R.string.weeksleepchart_sleep_a_week);
+        if (GBApplication.getPrefs().getBoolean("charts_range", true)) {
+            return getString(R.string.weeksleepchart_sleep_a_month);
+        }
+        else{
+            return getString(R.string.weeksleepchart_sleep_a_week);
+        }
     }
 
     @Override

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/WeekStepsChartFragment.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/WeekStepsChartFragment.java
@@ -30,7 +30,12 @@ import nodomain.freeyourgadget.gadgetbridge.model.ActivityUser;
 public class WeekStepsChartFragment extends AbstractWeekChartFragment {
     @Override
     public String getTitle() {
-        return getString(R.string.weekstepschart_steps_a_week);
+        if (GBApplication.getPrefs().getBoolean("charts_range", true)) {
+            return getString(R.string.weekstepschart_steps_a_month);
+        }
+        else{
+                return getString(R.string.weekstepschart_steps_a_week);
+        }
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -514,7 +514,7 @@
     <string name="activity_prefs_charts">Chart settings</string>
     <string name="activity_prefs_chart_max_heart_rate">Max heart rate</string>
     <string name="activity_prefs_chart_min_heart_rate">Min heart rate</string>
-    <string name="pref_charts_range">Charts Range</string>
+    <string name="pref_title_charts_range">Charts Range</string>
     <string name="pref_charts_range_on">Charts range is set to a Month</string>
     <string name="pref_charts_range_off">Charts range is set to a Week</string>
     <string name="weekstepschart_steps_a_month">Steps per month</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,9 +71,6 @@
     <string name="pref_title_general_autoreconnect">Reconnect automatically</string>
     <string name="pref_title_audio_player">Preferred Audioplayer</string>
     <string name="pref_default">Default</string>
-    <string name="pref_header_charts">Charts Settings</string>
-    <string name="pref_title_charts_swipe">Enable left/right swipe in the charts activity</string>
-    <string name="pref_title_charts_average">Show averages in the charts</string>
     <string name="pref_header_datetime">Date and Time</string>
     <string name="pref_title_datetime_syctimeonconnect">Sync time</string>
     <string name="pref_summary_datetime_syctimeonconnect">Sync time to Gadgetbridge device when connecting, and when time or time zone changes on Android device</string>
@@ -509,9 +506,20 @@
     <string name="activity_prefs_gender">Gender</string>
     <string name="activity_prefs_height_cm">Height in cm</string>
     <string name="activity_prefs_weight_kg">Weight in kg</string>
+
+    <!-- Settings - Charts Preferences -->
+    <string name="pref_header_charts">Charts Settings</string>
+    <string name="pref_title_charts_swipe">Enable left/right swipe in the charts activity</string>
+    <string name="pref_title_charts_average">Show averages in the charts</string>
     <string name="activity_prefs_charts">Chart settings</string>
     <string name="activity_prefs_chart_max_heart_rate">Max heart rate</string>
     <string name="activity_prefs_chart_min_heart_rate">Min heart rate</string>
+    <string name="pref_charts_range">Charts Range</string>
+    <string name="pref_charts_range_on">Charts range is set to a Month</string>
+    <string name="pref_charts_range_off">Charts range is set to a Week</string>
+    <string name="weekstepschart_steps_a_month">Steps per month</string>
+    <string name="weeksleepchart_sleep_a_month">Sleep per month</string>
+
     <string name="authenticating">Authenticating</string>
     <string name="authentication_required">Authentication required</string>
     <string name="appwidget_text">Zzz</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -195,7 +195,7 @@
             android:key="charts_range"
             android:summaryOff="@string/pref_charts_range_off"
             android:summaryOn="@string/pref_charts_range_on"
-            android:title="@string/pref_charts_range" />
+            android:title="@string/pref_title_charts_range" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -157,8 +157,8 @@
                 android:maxLength="3"
                 android:title="@string/activity_prefs_activetime_minutes" />
         </PreferenceScreen>
- </PreferenceCategory>
-<PreferenceCategory
+    </PreferenceCategory>
+    <PreferenceCategory
         android:title="@string/pref_header_charts">
         <PreferenceScreen
             android:key="pref_charts"
@@ -189,7 +189,15 @@
             android:key="charts_show_average"
             android:title="@string/pref_title_charts_average" />
 
+        <CheckBoxPreference
+            android:layout="@layout/preference_checkbox"
+            android:defaultValue="false"
+            android:key="charts_range"
+            android:summaryOff="@string/pref_charts_range_off"
+            android:summaryOn="@string/pref_charts_range_on"
+            android:title="@string/pref_charts_range" />
     </PreferenceCategory>
+
     <PreferenceCategory
         android:key="pref_key_datetime"
         android:title="@string/pref_header_datetime">


### PR DESCRIPTION
Actually a simple modification, which adds an options into Settings to change Charts **Steps per Week** and **Sleep per Week** into **Steps per Month** and **Sleep per Month**. 

Default is false, to keep traditional view.

When in Month view, Charts label, instead of short day name, uses day_of_month value, for better visibility.

Monthly charts seem quite dense at first due to axis values, but as they can be zoomed in, these values are actually very useful. This could perhaps be improved in the future by showing less density when zoomed in (like in the labels).

<img src="https://user-images.githubusercontent.com/3680926/62900205-e13b2700-bd59-11e9-81bf-8e979569fe3b.png" width=200 /> <img src="https://user-images.githubusercontent.com/3680926/62900037-5f4afe00-bd59-11e9-9d7a-e1274d38ec44.png" width=200 /> 
