### PR TITLE
Add 'Run AutoExport Now' button to database management

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DbManagementActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DbManagementActivity.java
@@ -17,13 +17,18 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 package nodomain.freeyourgadget.gadgetbridge.activities;
 
+import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.database.Cursor;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.provider.DocumentsContract;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
@@ -45,6 +50,7 @@ import nodomain.freeyourgadget.gadgetbridge.database.DBHandler;
 import nodomain.freeyourgadget.gadgetbridge.database.DBHelper;
 import nodomain.freeyourgadget.gadgetbridge.database.PeriodicExporter;
 import nodomain.freeyourgadget.gadgetbridge.entities.Device;
+import nodomain.freeyourgadget.gadgetbridge.util.AndroidUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.FileUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.GBPrefs;
@@ -104,7 +110,8 @@ public class DbManagementActivity extends AbstractGBActivity {
         Prefs prefs = GBApplication.getPrefs();
         boolean autoExportEnabled = prefs.getBoolean(GBPrefs.AUTO_EXPORT_ENABLED, false);
         Integer autoExportInterval = prefs.getInt(GBPrefs.AUTO_EXPORT_INTERVAL, 0);
-        String autoExportLocation = prefs.getString(GBPrefs.AUTO_EXPORT_LOCATION, "");
+        //returns an ugly content://...
+        //String autoExportLocation = prefs.getString(GBPrefs.AUTO_EXPORT_LOCATION, "");
 
         int testExportVisibility = (autoExportInterval > 0 && autoExportEnabled) ? View.VISIBLE : View.GONE;
 
@@ -114,21 +121,53 @@ public class DbManagementActivity extends AbstractGBActivity {
         TextView autoExportLocation_intro = findViewById(R.id.autoExportLocation_intro);
         autoExportLocation_intro.setVisibility(testExportVisibility);
 
-        TextView autoExportLocationview = findViewById(R.id.autoExportLocationview);
-        autoExportLocationview.setVisibility(testExportVisibility);
-        autoExportLocationview.setText(autoExportLocation);
+        TextView autoExportLocation_path = findViewById(R.id.autoExportLocation_path);
+        autoExportLocation_path.setVisibility(testExportVisibility);
+        autoExportLocation_path.setText(getAutoExportLocationSummary());
 
+        final Context context = getApplicationContext();
         Button testExportDBButton = findViewById(R.id.testExportDBButton);
         testExportDBButton.setVisibility(testExportVisibility);
         testExportDBButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                sendBroadcast(new Intent(getApplicationContext(), PeriodicExporter.class));
+                sendBroadcast(new Intent(context, PeriodicExporter.class));
+                GB.toast(context,
+                        context.getString(R.string.activity_DB_test_export_message),
+                        Toast.LENGTH_SHORT, GB.INFO);
             }
         });
 
         sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
     }
+
+    //would rather re-use method of SettingsActivity... but lifecycle...
+    private String getAutoExportLocationSummary() {
+        String autoExportLocation = GBApplication.getPrefs().getString(GBPrefs.AUTO_EXPORT_LOCATION, null);
+        if (autoExportLocation == null) {
+            return "";
+        }
+        Uri uri = Uri.parse(autoExportLocation);
+        try {
+            return AndroidUtils.getFilePath(getApplicationContext(), uri);
+        } catch (IllegalArgumentException e) {
+            try {
+                Cursor cursor = getContentResolver().query(
+                        uri,
+                        new String[]{DocumentsContract.Document.COLUMN_DISPLAY_NAME},
+                        null, null, null, null
+                );
+                if (cursor != null && cursor.moveToFirst()) {
+                    return cursor.getString(cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME));
+                }
+            }
+            catch (Exception fdfsdfds) {
+                LOG.warn("fuck");
+            }
+        }
+        return "";
+    }
+
 
     private boolean hasOldActivityDatabase() {
         return new DBHelper(this).existsDB("ActivityDatabase");

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DbManagementActivity.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/DbManagementActivity.java
@@ -19,6 +19,7 @@ package nodomain.freeyourgadget.gadgetbridge.activities;
 
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Bundle;
@@ -42,10 +43,13 @@ import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.R;
 import nodomain.freeyourgadget.gadgetbridge.database.DBHandler;
 import nodomain.freeyourgadget.gadgetbridge.database.DBHelper;
+import nodomain.freeyourgadget.gadgetbridge.database.PeriodicExporter;
 import nodomain.freeyourgadget.gadgetbridge.entities.Device;
 import nodomain.freeyourgadget.gadgetbridge.util.FileUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
+import nodomain.freeyourgadget.gadgetbridge.util.GBPrefs;
 import nodomain.freeyourgadget.gadgetbridge.util.ImportExportSharedPreferences;
+import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
 
 
 public class DbManagementActivity extends AbstractGBActivity {
@@ -94,6 +98,32 @@ public class DbManagementActivity extends AbstractGBActivity {
             @Override
             public void onClick(View v) {
                 deleteActivityDatabase();
+            }
+        });
+
+        Prefs prefs = GBApplication.getPrefs();
+        boolean autoExportEnabled = prefs.getBoolean(GBPrefs.AUTO_EXPORT_ENABLED, false);
+        Integer autoExportInterval = prefs.getInt(GBPrefs.AUTO_EXPORT_INTERVAL, 0);
+        String autoExportLocation = prefs.getString(GBPrefs.AUTO_EXPORT_LOCATION, "");
+
+        int testExportVisibility = (autoExportInterval > 0 && autoExportEnabled) ? View.VISIBLE : View.GONE;
+
+        TextView autoExportLocation_label = findViewById(R.id.autoExportLocation_label);
+        autoExportLocation_label.setVisibility(testExportVisibility);
+
+        TextView autoExportLocation_intro = findViewById(R.id.autoExportLocation_intro);
+        autoExportLocation_intro.setVisibility(testExportVisibility);
+
+        TextView autoExportLocationview = findViewById(R.id.autoExportLocationview);
+        autoExportLocationview.setVisibility(testExportVisibility);
+        autoExportLocationview.setText(autoExportLocation);
+
+        Button testExportDBButton = findViewById(R.id.testExportDBButton);
+        testExportDBButton.setVisibility(testExportVisibility);
+        testExportDBButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                sendBroadcast(new Intent(getApplicationContext(), PeriodicExporter.class));
             }
         });
 

--- a/app/src/main/res/layout/activity_db_management.xml
+++ b/app/src/main/res/layout/activity_db_management.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:grid="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -9,8 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <androidx.gridlayout.widget.GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:grid="http://schemas.android.com/apk/res-auto"
+        <androidx.gridlayout.widget.GridLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/activity_vertical_margin"
@@ -20,17 +20,27 @@
             grid:alignmentMode="alignBounds"
             grid:columnCount="2">
 
+            <TextView
+                android:id="@+id/exportImportLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/activity_db_management_exportimport_label"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="@color/accent"
+                grid:layout_columnSpan="2"
+                grid:layout_columnWeight="1" />
+
             <Button
                 android:id="@+id/exportDBButton"
-                android:text="Export DB"
+                android:text="@string/activity_DB_ExportButton"
                 grid:layout_column="0"
                 grid:layout_gravity="center" />
 
             <Button
                 android:id="@+id/importDBButton"
-                android:text="Import DB"
-                grid:layout_gravity="center"
-                grid:layout_column="1" />
+                android:text="@string/activity_DB_import_button"
+                grid:layout_column="1"
+                grid:layout_gravity="center" />
 
 
             <TextView
@@ -52,10 +62,46 @@
 
 
             <TextView
+                android:id="@+id/autoExportLocation_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:text="@string/activity_db_management_autoexport_label"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="@color/accent"
+                grid:layout_columnSpan="2"
+                grid:layout_columnWeight="1" />
+
+            <TextView
+                android:id="@+id/autoExportLocation_intro"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/activity_db_management_autoexport_explanation"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                grid:layout_columnSpan="2"
+                grid:layout_columnWeight="1" />
+
+            <TextView
+                android:id="@+id/autoExportLocationview"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                grid:layout_columnSpan="2"
+                grid:layout_columnWeight="1" />
+
+            <Button
+                android:id="@+id/testExportDBButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/activity_DB_test_export_button"
+                grid:layout_column="0"
+                grid:layout_gravity="center" />
+
+            <TextView
                 android:id="@+id/mergeOldActivityDataTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="40dp"
+                android:layout_marginTop="20dp"
                 android:text="@string/activity_db_management_merge_old_title"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:textColor="@color/accent"
@@ -68,14 +114,24 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="Delete old DB" />
+                android:text="@string/activity_DB_delete_legacy_button" />
+
+            <TextView
+                android:id="@+id/emptyActivityDataTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:text="@string/activity_db_management_empty_DB"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="@color/accent"
+                grid:layout_columnSpan="2"
+                grid:layout_columnWeight="1" />
 
             <TextView
                 android:id="@+id/emptyDBText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="40dp"
-                android:text="Warning! By pushing this button you will wipe your database and start from scratch."
+                android:text="@string/activity_db_management_empty_db_warning"
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 grid:layout_columnSpan="2"
                 grid:layout_columnWeight="1" />
@@ -84,7 +140,7 @@
                 android:id="@+id/emptyDBButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Empty DB" />
+                android:text="@string/activity_DB_empty_button" />
 
         </androidx.gridlayout.widget.GridLayout>
 

--- a/app/src/main/res/layout/activity_db_management.xml
+++ b/app/src/main/res/layout/activity_db_management.xml
@@ -30,18 +30,6 @@
                 grid:layout_columnSpan="2"
                 grid:layout_columnWeight="1" />
 
-            <Button
-                android:id="@+id/exportDBButton"
-                android:text="@string/activity_DB_ExportButton"
-                grid:layout_column="0"
-                grid:layout_gravity="center" />
-
-            <Button
-                android:id="@+id/importDBButton"
-                android:text="@string/activity_DB_import_button"
-                grid:layout_column="1"
-                grid:layout_gravity="center" />
-
 
             <TextView
                 android:id="@+id/db_management_intro"
@@ -56,10 +44,23 @@
                 android:id="@+id/activity_db_management_path"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:textStyle="bold"
                 grid:layout_columnSpan="2"
                 grid:layout_columnWeight="1" />
 
+
+            <Button
+                android:id="@+id/exportDBButton"
+                android:text="@string/activity_DB_ExportButton"
+                grid:layout_column="0"
+                grid:layout_gravity="center" />
+
+            <Button
+                android:id="@+id/importDBButton"
+                android:text="@string/activity_DB_import_button"
+                grid:layout_column="1"
+                grid:layout_gravity="center" />
 
             <TextView
                 android:id="@+id/autoExportLocation_label"
@@ -82,10 +83,11 @@
                 grid:layout_columnWeight="1" />
 
             <TextView
-                android:id="@+id/autoExportLocationview"
+                android:id="@+id/autoExportLocation_path"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:textStyle="bold"
                 grid:layout_columnSpan="2"
                 grid:layout_columnWeight="1" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,6 +565,17 @@
     <string name="dbmanagementactivity_old_activity_db_successfully_deleted">Old activity data deleted.</string>
     <string name="dbmanagementactivity_old_activity_db_deletion_failed">Old Activity database deletion failed.</string>
     <string name="dbmanagementactivity_overwrite">Overwrite</string>
+    <string name="activity_db_management_autoexport_explanation">Database autoexport location has been set to:</string>
+    <string name="activity_db_management_autoexport_label">AutoExport</string>
+    <string name="activity_DB_ExportButton">Export DB</string>
+    <string name="activity_DB_import_button">Import DB</string>
+    <string name="activity_DB_test_export_button">Test AutoExport Now</string>
+    <string name="activity_DB_delete_legacy_button">Delete old DB</string>
+    <string name="activity_DB_empty_button">Empty DB</string>
+    <string name="activity_db_management_empty_DB">Empty Database</string>
+    <string name="activity_db_management_exportimport_label">Export and Import</string>
+    <string name="activity_db_management_empty_db_warning">Warning! By pushing this button you will wipe your database and start from scratch.</string>
+
     <string name="Cancel">Cancel</string>
     <string name="Delete">Delete</string>
     <string name="ok">OK</string>
@@ -729,6 +740,5 @@
     <string name="widget_1_hour">1 hour</string>
     <string name="icon_placeholder" translatable="false">Icon</string>
     <string name="widget_alarm_target_hours">%d hours</string>
-
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -569,7 +569,8 @@
     <string name="activity_db_management_autoexport_label">AutoExport</string>
     <string name="activity_DB_ExportButton">Export DB</string>
     <string name="activity_DB_import_button">Import DB</string>
-    <string name="activity_DB_test_export_button">Test AutoExport Now</string>
+    <string name="activity_DB_test_export_button">Run AutoExport Now</string>
+    <string name="activity_DB_test_export_message">Exporting database...</string>
     <string name="activity_DB_delete_legacy_button">Delete old DB</string>
     <string name="activity_DB_empty_button">Empty DB</string>
     <string name="activity_db_management_empty_DB">Empty Database</string>


### PR DESCRIPTION
Simple addition which adds a button to the database management, to test the autoexport. It can help to try the auto export and perhaps also expose Permission Denial error.

summary:

- (conditionally) adds Test autoexport button
- moves several strings of activity_db_management into strings.xml
- adds few header labels to split the database management view

This button could have been added to Debug screen, but it feels more appropriate in DB management.