### PR TITLE
Show toast in case no app is installed which can handle GPX files

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/AndroidUtils.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/AndroidUtils.java
@@ -17,6 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 package nodomain.freeyourgadget.gadgetbridge.util;
 
+import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.ContentUris;
 import android.content.Context;
@@ -32,6 +33,7 @@ import android.os.Parcelable;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.text.TextUtils;
+import android.widget.Toast;
 
 import java.io.File;
 import java.io.IOException;
@@ -225,6 +227,10 @@ public class AndroidUtils {
                 context.getApplicationContext().getPackageName() + ".screenshot_provider", file);
         intent.setFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.setDataAndType(contentUri,"application/gpx+xml");
-        context.startActivity(intent);
+        try {
+            context.startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+            Toast.makeText(context, R.string.activity_error_no_app_for_gpx, Toast.LENGTH_LONG).show();
+        }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -505,6 +505,7 @@
     <string name="activity_summaries">Aktivitäten</string>
     <string name="activity_type_biking">Radfahren</string>
     <string name="activity_type_treadmill">Laufband</string>
+    <string name="activity_error_no_app_for_gpx">Um Aktivitäten zu betrachten, App installieren, die GPX-Dateien verarbeiten kann.</string>
     <string name="select_all">Alle auswählen</string>
     <string name="share">Teilen</string>
     <string name="reset_index">Abrufdatum zurücksetzen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -633,6 +633,7 @@
     <string name="activity_type_biking">Biking</string>
     <string name="activity_type_treadmill">Treadmill</string>
     <string name="activity_type_exercise">Exercise</string>
+    <string name="activity_error_no_app_for_gpx">To view activity trace, install app which can handle GPX files.</string>
     <string name="select_all">Select all</string>
     <string name="share">Share</string>
     <string name="reset_index">Reset fetch date</string>


### PR DESCRIPTION
As mentioned in https://github.com/Freeyourgadget/Gadgetbridge/issues/1636, the Gadgetbridge app crashes if no other app is installed which can handle GPX files and the user tries to open a GPX file anyway. The issue was closed, but in my opinion the situation should be handled more gracefully than letting the app crash without telling the user the reason for this behaviour.

With the changes in this PR the user will see a recommendation to install an app which can handle GPX files and the Gadgetbridge app will not crash.