### PR TITLE
Limit sleep charts range

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/AbstractChartFragment.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/AbstractChartFragment.java
@@ -712,6 +712,29 @@ public abstract class AbstractChartFragment extends AbstractGBFragment {
         return samples;
     }
 
+    protected List<? extends ActivitySample> getSamplesofSleep(DBHandler db, GBDevice device) {
+        int SLEEP_HOUR_LIMIT = 13;
+
+        int tsStart = getTSStart();
+        Calendar day = GregorianCalendar.getInstance();
+        day.setTimeInMillis(tsStart * 1000L);
+        day.set(Calendar.HOUR_OF_DAY, SLEEP_HOUR_LIMIT);
+        day.set(Calendar.MINUTE, 0);
+        day.set(Calendar.SECOND, 0);
+        tsStart = toTimestamp(day.getTime());
+
+        int tsEnd = getTSEnd();
+        day.setTimeInMillis(tsEnd* 1000L);
+        day.set(Calendar.HOUR_OF_DAY, SLEEP_HOUR_LIMIT);
+        day.set(Calendar.MINUTE, 0);
+        day.set(Calendar.SECOND, 0);
+        tsEnd = toTimestamp(day.getTime());
+
+        List<ActivitySample> samples = (List<ActivitySample>) getSamples(db, device, tsStart, tsEnd);
+        ensureStartAndEndSamples(samples, tsStart, tsEnd);
+        return samples;
+    }
+
     protected void ensureStartAndEndSamples(List<ActivitySample> samples, int tsStart, int tsEnd) {
         if (samples == null || samples.isEmpty()) {
             return;

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/SleepChartFragment.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/SleepChartFragment.java
@@ -75,13 +75,15 @@ public class SleepChartFragment extends AbstractChartFragment {
         List<? extends ActivitySample> samples = getSamplesofSleep(db, device);
 
         MySleepChartsData mySleepChartsData = refreshSleepAmounts(device, samples);
-        long tstart = mySleepChartsData.sleepSessions.get(0).getSleepStart().getTime() / 1000;
-        long tend = mySleepChartsData.sleepSessions.get(mySleepChartsData.sleepSessions.size() - 1).getSleepEnd().getTime() / 1000;
+        if (mySleepChartsData.sleepSessions.size()>0) {
+            long tstart = mySleepChartsData.sleepSessions.get(0).getSleepStart().getTime() / 1000;
+            long tend = mySleepChartsData.sleepSessions.get(mySleepChartsData.sleepSessions.size() - 1).getSleepEnd().getTime() / 1000;
 
-        for (Iterator<ActivitySample> iterator = (Iterator<ActivitySample>) samples.iterator(); iterator.hasNext(); ) {
-            ActivitySample sample = iterator.next();
-            if (sample.getTimestamp() < tstart || sample.getTimestamp() > tend) {
-                iterator.remove();
+            for (Iterator<ActivitySample> iterator = (Iterator<ActivitySample>) samples.iterator(); iterator.hasNext(); ) {
+                ActivitySample sample = iterator.next();
+                if (sample.getTimestamp() < tstart || sample.getTimestamp() > tend) {
+                    iterator.remove();
+                }
             }
         }
         DefaultChartsData chartsData = refresh(device, samples);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/SleepChartFragment.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/charts/SleepChartFragment.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -52,7 +53,6 @@ import nodomain.freeyourgadget.gadgetbridge.activities.HeartRateUtils;
 import nodomain.freeyourgadget.gadgetbridge.activities.charts.SleepAnalysis.SleepSession;
 import nodomain.freeyourgadget.gadgetbridge.database.DBHandler;
 import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
-import nodomain.freeyourgadget.gadgetbridge.model.ActivityAmount;
 import nodomain.freeyourgadget.gadgetbridge.model.ActivityKind;
 import nodomain.freeyourgadget.gadgetbridge.model.ActivitySample;
 import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
@@ -72,9 +72,18 @@ public class SleepChartFragment extends AbstractChartFragment {
 
     @Override
     protected ChartsData refreshInBackground(ChartsHost chartsHost, DBHandler db, GBDevice device) {
-        List<? extends ActivitySample> samples = getSamples(db, device);
+        List<? extends ActivitySample> samples = getSamplesofSleep(db, device);
 
         MySleepChartsData mySleepChartsData = refreshSleepAmounts(device, samples);
+        long tstart = mySleepChartsData.sleepSessions.get(0).getSleepStart().getTime() / 1000;
+        long tend = mySleepChartsData.sleepSessions.get(mySleepChartsData.sleepSessions.size() - 1).getSleepEnd().getTime() / 1000;
+
+        for (Iterator<ActivitySample> iterator = (Iterator<ActivitySample>) samples.iterator(); iterator.hasNext(); ) {
+            ActivitySample sample = iterator.next();
+            if (sample.getTimestamp() < tstart || sample.getTimestamp() > tend) {
+                iterator.remove();
+            }
+        }
         DefaultChartsData chartsData = refresh(device, samples);
 
         return new MyChartsData(mySleepChartsData, chartsData);


### PR DESCRIPTION
Addressing https://github.com/Freeyourgadget/Gadgetbridge/issues/1668 . 
This limits the "Your sleep" charts range to start with first detected sleep start and end with last detected sleep end. Possible improvement: Scale up, but need more samples due to possible need for HR measurements to be drawn correctly.