### PR TITLE
Allow apps to update existing notifications

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/externalevents/NotificationListener.java
@@ -266,7 +266,7 @@ public class NotificationListener extends NotificationListenerService {
         String source = sbn.getPackageName().toLowerCase();
         Notification notification = sbn.getNotification();
         if (notificationOldRepeatPrevention.containsKey(source)) {
-            if (notification.when <= notificationOldRepeatPrevention.get(source)) {
+            if (notification.when < notificationOldRepeatPrevention.get(source)) {
                 LOG.info("NOT processing notification, already sent newer notifications from this source.");
                 return;
             }


### PR DESCRIPTION
An app like [FairEmail](https://github.com/M66B/FairEmail/) first fetches the header of a message, displays a new message notification and later fetches the message text and updates the existing new message notification with the fetched message text. The latter might not happen if the message is large and the connection is metered (mobile or paid WiFi).

The minor change in this pull request makes updating the notification possible.