### PR TITLE
Catch crash during ChangeLog displaying

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
@@ -291,7 +291,11 @@ public class ControlCenterv2 extends AppCompatActivity
                 return true;
             case R.id.external_changelog:
                 ChangeLog cl = createChangeLog();
-                cl.getFullLogDialog().show();
+                try {
+                    cl.getLogDialog().show();
+                } catch (Exception ignored) {
+                    GB.toast(getBaseContext(), "Error showing Changelog", Toast.LENGTH_LONG, GB.ERROR);
+                }
                 return true;
         }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/activities/ControlCenterv2.java
@@ -31,6 +31,7 @@ import android.telephony.PhoneStateListener;
 import android.telephony.TelephonyManager;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBarDrawerToggle;
@@ -202,7 +203,12 @@ public class ControlCenterv2 extends AppCompatActivity
 
         ChangeLog cl = createChangeLog();
         if (cl.isFirstRun()) {
-            cl.getLogDialog().show();
+            try {
+                cl.getLogDialog().show();
+            } catch (Exception ignored){
+                GB.toast(getBaseContext(), "Error showing Changelog", Toast.LENGTH_LONG, GB.ERROR);
+
+            }
         }
 
         GBApplication.deviceService().start();


### PR DESCRIPTION
It doesn't handle the issue #1696 directly, as i couldn't find the real cause (perhaps i didn't dig deep enough) but at least we can catch the error and let the app continue. So it fixes #1696 and also subsequent trials to open Changelog from the menu.