### PR TITLE
Mi Band 4: Enable Emoji Font setting

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/huami/miband4/MiBand4Coordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/huami/miband4/MiBand4Coordinator.java
@@ -89,6 +89,7 @@ public class MiBand4Coordinator extends HuamiCoordinator {
         return new int[]{
                 R.xml.devicesettings_miband3,
                 R.xml.devicesettings_wearlocation,
+                R.xml.devicesettings_custom_emoji_font,
                 R.xml.devicesettings_dateformat,
                 R.xml.devicesettings_nightmode,
                 R.xml.devicesettings_liftwrist_display,


### PR DESCRIPTION
There is custom emoji font for Mi Band 4 at myamazfit.ru. We should enable custom font setting.